### PR TITLE
Bike Lanes Presence Data

### DIFF
--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -174,7 +174,7 @@ function osm2pgsql.process_way(object)
               object.tags["data:"..sign2side[sign]] = "not expected"
             end
           elseif transformation.prefix == 'bicycle' then
-            -- we have data
+            -- we (should) have data
             object.tags["data:"..sign2side[sign]] = "present"
           end
         end

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -129,12 +129,13 @@ function osm2pgsql.process_way(object)
           freshTag = "check_date:" .. cycleway._projected_to
         end
         IsFresh(object, freshTag, cycleway)
+        cycleway.offset  = sign * width / 2
         categoryTable:insert({
           category = category,
           tags = cycleway,
           meta = Metadata(object),
           geom = object:as_linestring(),
-          _offset = sign * width / 2
+          _offset = cycleway.offset
         })
         presence[sign] = presence[sign] or category
       end

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -199,7 +199,7 @@ function osm2pgsql.process_way(object)
   -- Filter ways where we dont expect bicycle infrastructure
   -- TODO: filter on surface and traffic zone
   -- TODO 2: into excludeTable
-  if Set({"path", "track", "residential", "unclassified", "service", "living_street", "pedestrian"," service", "motorway_link", "motorway", "footway", "steps"})[tags.highway] then
+  if Set({"path", "cycleway", "track", "residential", "unclassified", "service", "living_street", "pedestrian"," service", "motorway_link", "motorway", "footway", "steps"})[tags.highway] then
     intoExcludeTable(object, "no infrastructure expected for highway type: " .. tags.highway)
     return
   elseif tags.motorroad or tags.expressway or tags.cyclestreet or tags.bicycle_road then

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -113,7 +113,7 @@ function osm2pgsql.process_way(object)
   table.insert(cycleways, tags)
 
   -- map presence vis signs
-  local presence = { [1] = nil, [0] = nil, [-1] = nil }
+  local presence = { [LEFT_SIGN] = nil, [CENTER_SIGN] = nil, [RIGHT_SIGN] = nil }
   local width = RoadWidth(tags)
   for _, cycleway in pairs(cycleways) do
     local category = CategorizeBikelane(cycleway)
@@ -137,7 +137,7 @@ function osm2pgsql.process_way(object)
   end
   -- Filter ways where we dont expect bicycle infrastructure
   -- TODO: filter on surface and traffic zone and maxspeed
-  if not (presence[-1] or presence[0] or presence[1]) then
+  if not (presence[LEFT_SIGN] or presence[CENTER_SIGN] or presence[RIGHT_SIGN]) then
     if Set({ "path",
       "cycleway",
       "track",
@@ -169,8 +169,8 @@ function osm2pgsql.process_way(object)
   presenceTable:insert({
     tags = tags,
     geom = object:as_linestring(),
-    left = presence[1] or "no",
-    self = presence[0] or "no",
-    right = presence[-1] or "no"
+    left = presence[LEFT_SIGN] or "no",
+    self = presence[CENTER_SIGN] or "no",
+    right = presence[RIGHT_SIGN] or "no"
   })
 end

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -30,9 +30,9 @@ local presenceTable = osm2pgsql.define_table({
   columns = {
     { column = 'tags', type = 'jsonb' },
     { column = 'geom', type = 'linestring' },
-    { column = 'left', type = 'text'},
-    { column = 'self', type = 'text'},
-    { column = 'right', type = 'text'},
+    { column = 'left', type = 'text' },
+    { column = 'self', type = 'text' },
+    { column = 'right', type = 'text' },
   }
 })
 
@@ -96,7 +96,7 @@ function osm2pgsql.process_way(object)
     highway = "footway",
     prefix = "sidewalk",
     filter = function(tags)
-      return not(tags.footway=='no' or tags.footway == 'separate')
+      return not (tags.footway == 'no' or tags.footway == 'separate')
     end
   }
   -- cycleway transformer:
@@ -112,8 +112,8 @@ function osm2pgsql.process_way(object)
   tags.sign = 0
   table.insert(cycleways, tags)
 
-
-  local presence = {[1] = nil, [0] = nil, [-1] = nil}
+  -- map presence vis signs
+  local presence = { [1] = nil, [0] = nil, [-1] = nil }
   local width = RoadWidth(tags)
   for _, cycleway in pairs(cycleways) do
     local category = CategorizeBikelane(cycleway)
@@ -138,27 +138,27 @@ function osm2pgsql.process_way(object)
   -- Filter ways where we dont expect bicycle infrastructure
   -- TODO: filter on surface and traffic zone and maxspeed
   if not (presence[-1] or presence[0] or presence[1]) then
-    if Set({"path",
-            "cycleway",
-            "track",
-            "residential",
-            "unclassified",
-            "service",
-            "living_street",
-            "pedestrian",
-            "service",
-            "motorway_link",
-            "motorway",
-            "footway",
-            "steps"})[tags.highway] then
+    if Set({ "path",
+      "cycleway",
+      "track",
+      "residential",
+      "unclassified",
+      "service",
+      "living_street",
+      "pedestrian",
+      "service",
+      "motorway_link",
+      "motorway",
+      "footway",
+      "steps" })[tags.highway] then
       intoExcludeTable(object, "no infrastructure expected for highway type: " .. tags.highway)
       return
     elseif tags.motorroad or tags.expressway or tags.cyclestreet or tags.bicycle_road then
       intoExcludeTable(object, "no (extra) infrastructure expected for motorroad, express way and cycle streets")
-    return
-    -- elseif tags.maxspeed and tags.maxspeed <= 20 then
-    --   intoExcludeTable(object, "no infrastructure expected for max speed <= 20 kmh")
-    --   return
+      return
+      -- elseif tags.maxspeed and tags.maxspeed <= 20 then
+      --   intoExcludeTable(object, "no infrastructure expected for max speed <= 20 kmh")
+      --   return
     end
   end
 

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -10,6 +10,7 @@ require("StartsWith")
 require("IsFresh")
 require("categories")
 require("transformations")
+require("PrintTable")
 
 local table = osm2pgsql.define_table({
   name = '_bikelanes_temp',
@@ -58,7 +59,8 @@ local presenceTable = osm2pgsql.define_table({
 
 -- whitelist of tags we want to insert intro the DB
 local allowed_tags = Set({
-  "_projected_tag",
+  "_projected_from",
+  "_projected_to",
   "access",
   "bicycle_road",
   "bicycle",
@@ -85,40 +87,6 @@ local function intoExcludeTable(object, reason)
     reason = reason,
     geom = object:as_linestring()
   })
-end
-
--- transform all tags from ["prefix:subtag"]=val -> ["subtag"]=val
-local function transformTags(tags, prefix)
-  local transformedTags = { _projected_tag = prefix }
-  for prefixedKey, val in pairs(tags) do
-    if prefixedKey ~= prefix and StartsWith(prefixedKey, prefix) then
-      -- offset of 2 due to 1-indexing and for removing the ':'
-      local key = string.sub(prefixedKey, string.len(prefix) + 2)
-      transformedTags[key] = val
-    end
-  end
-  return transformedTags
-end
-
-function applyTransformation(object, transformation)
-  local result = {}
-  local sides = {
-    [":right"] = { -1 },
-    [":left"] = { 1 },
-    [":both"] = { -1, 1 },
-    [""] = { -1, 1 }
-  }
-  for side, signs in pairs(sides) do
-    local prefixedSide = transformation.prefix .. side
-    local cycleway = transformTags(object.tags, prefixedSide)
-    cycleway[transformation.prefix] = object.tags[prefixedSide] -- project `prefix:side` to `prefix`
-    cycleway.highway = transformation.highway
-    cycleway.name = object.name
-    IsFresh(object, "check_date:" .. transformation.prefix, cycleway)
-    -- post processing to filter oneway
-    result[cycleway] = signs
-  end
-  return result
 end
 
 function osm2pgsql.process_way(object)
@@ -148,70 +116,60 @@ function osm2pgsql.process_way(object)
   end
 
   -- categorize bike lanes (nested)
-  local sides = {
-    [":right"] = { -1 },
-    [":left"] = { 1 },
-    [":both"] = { -1, 1 },
-    [""] = { -1, 1 }
+-- footway transformer: transforms all sidewalk:<side>:bicycle = val
+  local footwayTransformation = {
+    highway = "footway",
+    prefix = "sidewalk",
   }
+
+  -- cycleway transformer:
+  local cyclewayTransformation = {
+    highway = "cycleway",
+    prefix = "cycleway",
+  }
+
+  local transformations = { cyclewayTransformation, footwayTransformation } -- order matters for presence
+
   local width = RoadWidth(tags)
   local presence = {[1] = nil, [-1] = nil}
-  for _, transformation in pairs(Transformations) do
-    for side, signs in pairs(sides) do
-      local prefix = transformation.prefix
-      local prefixedSide = prefix .. side
-      -- this is the transformation:
-      local cycleway = transformTags(tags, prefixedSide)
-      cycleway.highway = transformation.highway
-      cycleway[prefix] = tags[prefixedSide] -- project `prefix:side` to `prefix`
-      category = CategorizeBikelane(cycleway)
-      for _, sign in pairs(signs) do
-        if cycleway[prefix] == "no" or cycleway[prefix] == "separate" then
-          if prefix == 'cycleway' then
-            -- we might have data but need to find it
-            presence[sign] = presence[sign] or "present"
-          end
-        else
-          local isOneway = tags['oneway'] == 'yes' and tags['oneway:bicycle'] ~= 'no'
-          if not (side == "" and sign > 0 and isOneway and prefix == 'bicycle') then
-            if category ~= nil then
-              FilterTags(cycleway, allowed_tags)
-              IsFresh(object, "check_date:" .. prefix, cycleway)
-              transformTable:insert({
-                category = category,
-                tags = cycleway,
-                meta = Metadata(object),
-                geom = object:as_linestring(),
-                offset = sign * width / 2
-              })
-              -- we have data and know it
-              presence[sign] = presence[sign] or "present"
-            end
-          else
-            -- we don't expect data
-            presence[sign] = presence[sign] or "not_expected"
-          end
-        end
-      end
+  local cycleways = GetTransformedObjects(object, transformations);
+  print("\n\n ")
+  for _, cycleway in pairs(cycleways) do
+    -- print(cycleway.sign)
+    PrintTable(cycleway)
+    category = CategorizeBikelane(cycleway)
+    if category ~= nil then
+      local sign = cycleway.sign
+      FilterTags(cycleway, allowed_tags)
+      -- IsFresh(object, "check_date:" .. cycleway._projected_to, cycleway)
+      transformTable:insert({
+        category = category,
+        tags = cycleway,
+        meta = Metadata(object),
+        geom = object:as_linestring(),
+        offset = sign * width / 2
+      })
+      presence[sign] = presence[sign] or category
     end
   end
-
   -- Filter ways where we dont expect bicycle infrastructure
-  -- TODO: filter on surface and traffic zone
-  -- TODO 2: into excludeTable
-  if Set({"path", "cycleway", "track", "residential", "unclassified", "service", "living_street", "pedestrian"," service", "motorway_link", "motorway", "footway", "steps"})[tags.highway] then
-    intoExcludeTable(object, "no infrastructure expected for highway type: " .. tags.highway)
+  -- TODO: filter on surface and traffic zone and maxspeed
+  if not (presence[-1] or presence[1]) then
+    if Set({"path", "cycleway", "track", "residential", "unclassified", "service", "living_street", "pedestrian"," service", "motorway_link", "motorway", "footway", "steps"})[tags.highway] then
+      intoExcludeTable(object, "no infrastructure expected for highway type: " .. tags.highway)
+      return
+    elseif tags.motorroad or tags.expressway or tags.cyclestreet or tags.bicycle_road then
+      intoExcludeTable(object, "no (extra) infrastructure expected for motorroad, express way and cycle streets")
     return
-  elseif tags.motorroad or tags.expressway or tags.cyclestreet or tags.bicycle_road then
-    intoExcludeTable(object, "no (extra) infrastructure expected for motorroad, express way and cycle streets")
-    return
-  -- elseif tags.maxspeed and tags.maxspeed <= 20 then
-  --   intoExcludeTable(object, "no infrastructure expected for max speed <= 20 kmh")
-  --   return
+    -- elseif tags.maxspeed and tags.maxspeed <= 20 then
+    --   intoExcludeTable(object, "no infrastructure expected for max speed <= 20 kmh")
+    --   return
+    end
   end
   -- TODO excludeTable: For ZES, we exclude "Verbindungsstücke", especially for the "cyclewayAlone" case
   -- We would have to do this in a separate processing step or wait for length() data to be available in LUA
   -- MORE: osm-scripts-Repo => utils/Highways-BicycleWayData/filter/radwegVerbindungsstueck.ts
+
   presenceTable:insert({
     tags = tags,
     geom = object:as_linestring(),

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -136,7 +136,7 @@ function osm2pgsql.process_way(object)
         if category ~= nil then
           for _, sign in pairs(signs) do
             local isOneway = object.tags['oneway'] == 'yes' and object.tags['oneway:bicycle'] ~= 'no'
-            if not (side == "" and sign > 0 and isOneway) then -- skips implicit case for oneways TODO: dont skip on sidewalk transformation
+            if not (side == "" and sign > 0 and isOneway and transformation.prefix == 'bicycle') then
               FilterTags(cycleway, allowed_tags)
               IsFresh(object, "check_date:" .. transformation.prefix, cycleway)
               transformTable:insert({

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -189,7 +189,7 @@ function osm2pgsql.process_way(object)
             end
           else
             -- we don't expect data
-            presence[sign] = presence[sign] or "not expected"
+            presence[sign] = presence[sign] or "not_expected"
           end
         end
       end

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -106,12 +106,15 @@ function osm2pgsql.process_way(object)
   }
   local transformations = { cyclewayTransformation, footwayTransformation } -- order matters for presence
 
-
-  local width = RoadWidth(tags)
-  local presence = {[1] = nil, [0] = nil, [-1] = nil}
+  -- generate cycleways from center line tagging
   local cycleways = GetTransformedObjects(tags, transformations);
+  -- add the original object with `sign=0`
   tags.sign = 0
   table.insert(cycleways, tags)
+
+
+  local presence = {[1] = nil, [0] = nil, [-1] = nil}
+  local width = RoadWidth(tags)
   for _, cycleway in pairs(cycleways) do
     local category = CategorizeBikelane(cycleway)
     if category ~= nil then

--- a/app/process/bikelanes/bikelanes.sql
+++ b/app/process/bikelanes/bikelanes.sql
@@ -1,11 +1,12 @@
--- What happens:
+-- remove categories which are only used for checking the presence of data
+DELETE FROM "_bikelanes_temp" WHERE category='only_data' OR category='not_expected';
+
+-- What happens here:
 -- we project to cartesian coordinates
 -- move the geometry by `_offset` (+ left / - right)
 -- because negative offsets reverse the order and we want the right side to be aligned we reverse the order again
 -- additionally we check wether the geometry is `simple` because otherwise we might get a MLString
--- remove categories which are only used for checking the presence of data
-DELETE FROM "_bikelanes_temp" WHERE category='only_data' OR category='not_expected';
-
+-- for the same reason we simplify the geometries
 -- TODO: check parameters `quad_segs` and  `join`
 UPDATE "_bikelanes_temp"
   SET geom=ST_Reverse(ST_Transform(ST_OffsetCurve(ST_Simplify(ST_Transform(geom, 25833), 0.5), "_offset", 'quad_segs=4 join=round'), 3857))
@@ -20,6 +21,7 @@ ALTER TABLE "_bikelanes_temp" DROP COLUMN "_offset";
 
 --IDEA: maybe we can transform closed geometries with some sort of buffer function:
 -- at least for the cases where we buffer "outside"(side=right) this should always yield a LineString
+-- IDEA 2: scale around center of geom (would require to estimate the scaling factor)
 
 
 -- Query below shows the geometries that would result in MultiLineString

--- a/app/process/bikelanes/bikelanes.sql
+++ b/app/process/bikelanes/bikelanes.sql
@@ -1,28 +1,26 @@
 -- What happens:
 -- we project to cartesian coordinates
--- move the geometry by `offset` (+ left / - right)
+-- move the geometry by `_offset` (+ left / - right)
 -- because negative offsets reverse the order and we want the right side to be aligned we reverse the order again
 -- additionally we check wether the geometry is `simple` because otherwise we might get a MLString
+-- remove categories which are only used for checking the presence of data
+DELETE FROM "_bikelanes_temp" WHERE category='only_data' OR category='not_expected';
+
 -- TODO: check parameters `quad_segs` and  `join`
-UPDATE "_bikelanes_transformed"
-  SET geom=ST_Reverse(ST_Transform(ST_OffsetCurve(ST_Simplify(ST_Transform(geom, 25833), 0.5), "offset", 'quad_segs=4 join=round'), 3857))
-  WHERE ST_IsSimple(geom) and not ST_IsClosed(geom) and "offset"!=0;
-
-
-UPDATE "_synthetic_excluded"
-  SET geom=ST_Reverse(ST_Transform(ST_OffsetCurve(ST_Simplify(ST_Transform(geom, 25833), 1), "offset", 'quad_segs=4 join=round'), 3857))
-  WHERE ST_IsSimple(geom) and not ST_IsClosed(geom) and "offset"!=0;
---IDEA: maybe we can transform closed geometries with some sort of buffer function:
--- at least for the cases where we buffer "outside"(side=right) this should always yield a LineString
+UPDATE "_bikelanes_temp"
+  SET geom=ST_Reverse(ST_Transform(ST_OffsetCurve(ST_Simplify(ST_Transform(geom, 25833), 0.5), "_offset", 'quad_segs=4 join=round'), 3857))
+  WHERE ST_IsSimple(geom) and not ST_IsClosed(geom) and "_offset"!=0;
 
 -- We need a unique osm_id for our frontend code. As a workaround we use the offset sign.
 -- In turn this brakes updating tables via osm2pgsql
-UPDATE "_bikelanes_transformed"
-  SET osm_id=osm_id*SIGN("offset");
+UPDATE "_bikelanes_temp"
+  SET osm_id=osm_id*SIGN("_offset");
 
-INSERT INTO "_bikelanes_temp"
-  SELECT osm_type, osm_id, category, tags, meta, geom
-  FROM "_bikelanes_transformed";
+ALTER TABLE "_bikelanes_temp" DROP COLUMN "_offset";
+
+--IDEA: maybe we can transform closed geometries with some sort of buffer function:
+-- at least for the cases where we buffer "outside"(side=right) this should always yield a LineString
+
 
 -- Query below shows the geometries that would result in MultiLineString
--- SELECT * from "_bikelanes_transformed" WHERE not ST_IsSimple(geom) or ST_IsClosed(geom);
+-- SELECT * from "_bikelanes_temp" WHERE not ST_IsSimple(geom) or ST_IsClosed(geom);

--- a/app/process/bikelanes/bikelanes.sql
+++ b/app/process/bikelanes/bikelanes.sql
@@ -16,7 +16,7 @@ UPDATE "_bikelanes_temp"
 UPDATE "_bikelanes_temp"
   SET osm_id=osm_id*SIGN("_offset");
 
-ALTER TABLE "_bikelanes_temp" DROP COLUMN "_offset";
+-- ALTER TABLE "_bikelanes_temp" DROP COLUMN "_offset";
 
 --IDEA: maybe we can transform closed geometries with some sort of buffer function:
 -- at least for the cases where we buffer "outside"(side=right) this should always yield a LineString

--- a/app/process/bikelanes/bikelanes.sql
+++ b/app/process/bikelanes/bikelanes.sql
@@ -5,9 +5,13 @@
 -- additionally we check wether the geometry is `simple` because otherwise we might get a MLString
 -- TODO: check parameters `quad_segs` and  `join`
 UPDATE "_bikelanes_transformed"
-  SET geom=ST_Reverse(ST_Transform(ST_OffsetCurve(ST_Simplify(ST_Transform(geom, 25833), 0.05), "offset", 'quad_segs=4 join=round'), 3857))
+  SET geom=ST_Reverse(ST_Transform(ST_OffsetCurve(ST_Simplify(ST_Transform(geom, 25833), 0.5), "offset", 'quad_segs=4 join=round'), 3857))
   WHERE ST_IsSimple(geom) and not ST_IsClosed(geom) and "offset"!=0;
 
+
+UPDATE "_synthetic_excluded"
+  SET geom=ST_Reverse(ST_Transform(ST_OffsetCurve(ST_Simplify(ST_Transform(geom, 25833), 1), "offset", 'quad_segs=4 join=round'), 3857))
+  WHERE ST_IsSimple(geom) and not ST_IsClosed(geom) and "offset"!=0;
 --IDEA: maybe we can transform closed geometries with some sort of buffer function:
 -- at least for the cases where we buffer "outside"(side=right) this should always yield a LineString
 

--- a/app/process/bikelanes/bikelanes.sql
+++ b/app/process/bikelanes/bikelanes.sql
@@ -1,5 +1,4 @@
 -- remove categories which are only used for checking the presence of data
-DELETE FROM "_bikelanes_temp" WHERE category='only_data' OR category='not_expected';
 
 -- What happens here:
 -- we project to cartesian coordinates

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -8,11 +8,11 @@ local function onlyData(tags)
   end
 end
 
--- this category is for the implicit absence in oneways
+-- for oneways we assume that the tag `cycleway=*` significates that there's one bike line on the left
 local function implicitOneWay(tags)
   local result = tags.parent ~= nil and tags['_projected_from'] == 'cycleway' -- object is created from implicit case
   result = result and tags.parent.oneway == 'yes' and tags.parent['oneway:bicycle'] ~= 'no' -- is oneway w/o bike exception
-  result = result and tags.sign > 0 -- it's the left object (in driving direction)
+  result = result and tags.sign == LEFT_SIGN
   if result then
     return 'not_expected'
   end

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -9,6 +9,7 @@ local function dataNo(tags)
 end
 
 -- for oneways we assume that the tag `cycleway=*` significates that there's one bike line on the left
+-- TODO: this assumes right hand traffic (would be nice to have this as an option)
 local function implicitOneWay(tags)
   local result = tags.parent ~= nil and tags['_projected_from'] == 'cycleway' -- object is created from implicit case
   result = result and tags.parent.oneway == 'yes' and tags.parent['oneway:bicycle'] ~= 'no' -- is oneway w/o bike exception

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -2,9 +2,9 @@
 
 -- this category is for the explicit absence of bike infrastrucute
 -- TODO: split into `no` or `separate`
-local function onlyData(tags)
+local function dataNo(tags)
   if tags.cycleway == 'no' or tags.cycleway == 'separate' then
-    return "only_data"
+    return "data_no"
   end
 end
 
@@ -146,10 +146,7 @@ local function cyclewayBuslane(tags)
   end
 end
 
-function CategorizeBikelane(tags)
-  local categories = { onlyData, implicitOneWay, pedestiranArea, livingStreet, bicycleRoad, footAndCycleway,
-    footAndCyclewaySegregated,
-    footwayBicycleAllowed, cyclewaySeparated, cyclewayOnHighway, cyclewayAlone, cyclewayBuslane }
+local function defineCategory(tags, categories)
   for _, predicate in pairs(categories) do
     local category = predicate(tags)
     if category ~= nil then
@@ -157,4 +154,17 @@ function CategorizeBikelane(tags)
     end
   end
   return nil
+end
+
+-- Categories for objects where no infrastructure is available but the data is considered complete
+function OnlyPresent(tags)
+  local dataCategories = { dataNo, implicitOneWay}
+  return defineCategory(tags, dataCategories)
+end
+
+function CategorizeBikelane(tags)
+  local categories = { pedestiranArea, livingStreet, bicycleRoad, footAndCycleway,
+    footAndCyclewaySegregated,
+    footwayBicycleAllowed, cyclewaySeparated, cyclewayOnHighway, cyclewayAlone, cyclewayBuslane }
+  return defineCategory(tags, categories)
 end

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -10,9 +10,8 @@ end
 
 -- this category is for the implicit absence in oneways
 local function implicitOneWay(tags)
-  local result = tags.parent ~= nil
+  local result = tags.parent ~= nil and tags['_projected_from'] == 'cycleway' -- object is created from implicit case
   result = result and tags.parent.oneway == 'yes' and tags.parent['oneway:bicycle'] ~= 'no' -- is oneway w/o bike exception
-  result = result and tags['_projected_from'] == 'cycleway' -- object is created from implicit case
   result = result and tags.sign > 0  -- it's the left object (in driving direction)
   if result then
     return 'not_expected'

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -102,7 +102,7 @@ local function cyclewaySeparated(tags)
     -- Case: The crossing version of a separate cycleway next to a road
     -- The same case as the is_sidepath=yes above, but on crossings we don't set that.
     --    Eg https://www.openstreetmap.org/way/963592923
-    -- result = result or tags.cycleway == "crossing"
+    result = result or tags.cycleway == "crossing"
     -- Case: Separate cycleway identified via "track"-tagging. Only handle through center line!
     --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dtrack
     --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dopposite_track

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -111,7 +111,7 @@ end
 -- Eg. https://www.openstreetmap.org/way/27701956
 -- traffic_sign=DE:237, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic%20sign=DE:237
 -- tag: "cyclewayAlone"
-local function cycleWayAlone(tags)
+local function cyclewayAlone(tags)
   local result = tags.highway == "cycleway" and tags.traffic_sign == "DE:237"
   result = result and (tags.is_sidepath == nil or tags.is_sidepath == "no")
   if result then
@@ -119,9 +119,16 @@ local function cycleWayAlone(tags)
   end
 end
 
+local function cyclewayBuslane(tags)
+  -- TODO: check for other cases
+  if tags.highway == "cycleway" and tags.cycleway == "share_busway" then
+    return "cyclewayAlone"
+  end
+end
+
 function CategorizeBikelane(tags)
   local categories = { pedestiranArea, livingStreet, bicycleRoad, footAndCycleway, footAndCyclewaySegregated,
-    footwayBicycleAllowed, cyclewaySeparated, cyclewayOnHighway, cycleWayAlone }
+    footwayBicycleAllowed, cyclewaySeparated, cyclewayOnHighway, cyclewayAlone, cyclewayBuslane }
   for _, predicate in pairs(categories) do
     local category = predicate(tags)
     if category ~= nil then

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -12,7 +12,7 @@ end
 local function implicitOneWay(tags)
   local result = tags.parent ~= nil and tags['_projected_from'] == 'cycleway' -- object is created from implicit case
   result = result and tags.parent.oneway == 'yes' and tags.parent['oneway:bicycle'] ~= 'no' -- is oneway w/o bike exception
-  result = result and tags.sign > 0  -- it's the left object (in driving direction)
+  result = result and tags.sign > 0 -- it's the left object (in driving direction)
   if result then
     return 'not_expected'
   end
@@ -102,7 +102,7 @@ local function cyclewaySeparated(tags)
     -- Case: The crossing version of a separate cycleway next to a road
     -- The same case as the is_sidepath=yes above, but on crossings we don't set that.
     --    Eg https://www.openstreetmap.org/way/963592923
-    result = result or tags.cycleway == "crossing"
+    -- result = result or tags.cycleway == "crossing"
     -- Case: Separate cycleway identified via "track"-tagging. Only handle through center line!
     --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dtrack
     --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dopposite_track
@@ -139,13 +139,16 @@ end
 
 local function cyclewayBuslane(tags)
   -- TODO: check for other cases
-  if tags.highway == "cycleway" and tags.cycleway == "share_busway" then
+  local result = tags.highway == "cycleway"
+  result = result and tags.cycleway == "share_busway" or tags.cycleway == "opposite_share_busway"
+  if result then
     return "cyclewayAlone"
   end
 end
 
 function CategorizeBikelane(tags)
-  local categories = { onlyData, implicitOneWay, pedestiranArea, livingStreet, bicycleRoad, footAndCycleway, footAndCyclewaySegregated,
+  local categories = { onlyData, implicitOneWay, pedestiranArea, livingStreet, bicycleRoad, footAndCycleway,
+    footAndCyclewaySegregated,
     footwayBicycleAllowed, cyclewaySeparated, cyclewayOnHighway, cyclewayAlone, cyclewayBuslane }
   for _, predicate in pairs(categories) do
     local category = predicate(tags)

--- a/app/process/bikelanes/transformations.lua
+++ b/app/process/bikelanes/transformations.lua
@@ -44,6 +44,13 @@ function GetTransformedObjects(tags, transformations)
             transformedObj.sign = sign
             table.insert(transformedObjects, transformedObj)
           end
+          if transformedObj.lanes == nil and false then
+            if sign == RIGHT_SIGN then
+              transformedObj.lanes = transformedObj['lanes:forward']
+            elseif sign == LEFT_SIGN then
+              transformedObj.lanes = transformedObj['lanes:backward']
+            end
+          end
         end
       end
     end

--- a/app/process/bikelanes/transformations.lua
+++ b/app/process/bikelanes/transformations.lua
@@ -26,7 +26,7 @@ function GetTransformedObjects(tags, transformations)
   local transformedObjects = {}
   for _, transformation in pairs(transformations) do
     for side, signs in pairs(sides) do
-
+      -- TODO: take :both as scelleton and overwrite with specific tags from :left or :right (maybe also from implicit both)
       for _, sign in pairs(signs) do
         -- this is the transformation:
         local prefix = transformation.prefix
@@ -45,10 +45,13 @@ function GetTransformedObjects(tags, transformations)
             table.insert(transformedObjects, transformedObj)
           end
           if transformedObj.lanes == nil and false then
+            -- TODO: this assumes right hand traffic (would be nice to have this as an option)
             if sign == RIGHT_SIGN then
-              transformedObj.lanes = transformedObj['lanes:forward']
+              transformedObj['cycleway:lanes'] = transformedObj['cycleway:lanes:forward']
+              transformedObj['bicycle:lanes'] = transformedObj['bicycle:lanes:forward']
             elseif sign == LEFT_SIGN then
-              transformedObj.lanes = transformedObj['lanes:backward']
+              transformedObj['cycleway:lanes'] = transformedObj['cycleway:lanes:backward']
+              transformedObj['bicycle:lanes'] = transformedObj['bicycle:lanes:backward']
             end
           end
         end

--- a/app/process/bikelanes/transformations.lua
+++ b/app/process/bikelanes/transformations.lua
@@ -13,12 +13,15 @@ local function unnestTags(tags, prefix, dest)
 end
 
 -- returns a list of all transformed objects created with the given `transformations` from `tags`
+LEFT_SIGN = 1
+CENTER_SIGN = 0
+RIGHT_SIGN = -1
 function GetTransformedObjects(tags, transformations)
   local sides = {
-    [":right"] = { -1 },
-    [":left"] = { 1 },
-    [":both"] = { -1, 1 },
-    [""] = { -1, 1 },
+    [":left"] = { LEFT_SIGN },
+    [":right"] = { RIGHT_SIGN },
+    [":both"] = { LEFT_SIGN, RIGHT_SIGN },
+    [""] = { LEFT_SIGN, RIGHT_SIGN },
   }
   local transformedObjects = {}
   for _, transformation in pairs(transformations) do

--- a/app/process/bikelanes/transformations.lua
+++ b/app/process/bikelanes/transformations.lua
@@ -1,13 +1,3 @@
--- This file defines the `Transformations` which are used to process center line tagged bike lanes
--- `highway` is the new highway type for the generated object
--- `prefix` will be concatinated wiht one of the sides `':left' | ':right' | ':both' | '' `
--- all tags wich have the concatination as a preix get projected -> w\o prefix
--- postProcessing() gets called before inserting the transformed object into the table and has the following params:
--- `parent` (tags of original object)
--- `cycleway` (transformed object)
--- `category` the category of the transformed cycleway
--- return an int which gets added onto the offset value
-
 -- unnest all tags from ["prefix:subtag"]=val -> ["subtag"]=val
 local function unnestTags(tags, prefix, dest)
   dest = dest or {}
@@ -22,7 +12,7 @@ local function unnestTags(tags, prefix, dest)
   return dest
 end
 
-
+-- returns a list of all transformed objects created with the given `transformations` from `tags`
 function GetTransformedObjects(tags, transformations)
   local sides = {
     [":right"] = { -1 },

--- a/app/process/shared/IsFresh.lua
+++ b/app/process/shared/IsFresh.lua
@@ -2,8 +2,8 @@
 --    If present, use `date_tag` (high confidence).
 --    Fall back to `object.timestamp` (low confidence).
 -- * @returns
---   `dest` if provided with freshness-tags added to it.
---   Otherwise a new object with freshness-tags is returned.
+--   `dest` with freshness-tags added to it.
+--   If no parameter was provided a new object gets created.
 function IsFresh(object, date_tag, dest)
   dest = dest or {}
 


### PR DESCRIPTION
This PR introduce a new table `bikelanes_presence` which holds information about the presence/availability of bike infrastructure tags. 

There are 3 keys per object:
- `left` | `right` - is the category of the center line generated objects or `no`
- `center` - is the category of the object itself or `no`

For that we introduce a new type of categories `OnlyPresent`,  which for now includes  `data_no` and `not_expected` .
These categories can appear in `bikelanes_presence` but never in `bikelanes`.

There function is to detect data which is considered by us to be complete (respecting bike infrastructure) but where no infrastructure is available (e.g. the explicit presence of no's).
These are higher prioritized than the normal categories and exclusive, which means if an `OnlyPresent` category applied to an object it won't be considered for further categories.... (E.g. they work like a filter).

Furthermore we abstracted the whole logic of the center line processing in `biklanes.lua` file. The function to perform the transformations is called `GetTransformedObjects()` and lies in the `/bikelanes/transformations.lua` . 
As a result of this abstraction we handle the transformed objects and the original object in the same manner and add them to the same table (original object has `offset=0`).