### PR TITLE
Center Line: Data Inheritance

### DIFF
--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -83,7 +83,7 @@ end
 
 function osm2pgsql.process_way(object)
   -- filter highway classes
-  local allowed_highways = JoinSets(StreetClasses, PathClasses)
+  local allowed_highways = JoinSets({StreetClasses, PathClasses})
   if not object.tags.highway or not allowed_highways[object.tags.highway] then return end
 
   local exclude, reason = ExcludeHighways(object.tags)

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -66,6 +66,7 @@ local allowed_tags = Set({
   "segregated",
   "smoothness",
   "surface",
+  "surface:color",
   "traffic_sign",
   "width", -- experimental
 })

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -26,7 +26,7 @@ local categoryTable = osm2pgsql.define_table({
 })
 
 local presenceTable = osm2pgsql.define_table({
-  name = 'bikelanes_presence',
+  name = 'bikelanesPresence',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
     { column = 'tags', type = 'jsonb' },

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -10,6 +10,7 @@ require("StartsWith")
 require("IsFresh")
 require("categories")
 require("transformations")
+require("JoinSets")
 require("PrintTable")
 
 local categoryTable = osm2pgsql.define_table({
@@ -82,7 +83,8 @@ end
 
 function osm2pgsql.process_way(object)
   -- filter highway classes
-  if not object.tags.highway or not HighwayClasses[object.tags.highway] then return end
+  local allowed_highways = JoinSets(StreetClasses, PathClasses)
+  if not object.tags.highway or not allowed_highways[object.tags.highway] then return end
 
   local exclude, reason = ExcludeHighways(object.tags)
   if exclude then

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -61,7 +61,6 @@ local allowed_tags = Set({
   "footway",
   "highway",
   "is_sidepath",
-  "mtb:scale",
   "name",
   "oneway", -- we use oneway:bicycle=no (which is transformed to oneway=no) to add a notice in the UI about two way cycleways in one geometry
   "segregated",
@@ -83,7 +82,7 @@ end
 
 function osm2pgsql.process_way(object)
   -- filter highway classes
-  local allowed_highways = JoinSets({StreetClasses, PathClasses})
+  local allowed_highways = JoinSets({HighwayClasses, MajorRoadClasses, MinorRoadClasses, PathClasses})
   if not object.tags.highway or not allowed_highways[object.tags.highway] then return end
 
   local exclude, reason = ExcludeHighways(object.tags)
@@ -144,19 +143,7 @@ function osm2pgsql.process_way(object)
   -- Filter ways where we dont expect bicycle infrastructure
   -- TODO: filter on surface and traffic zone and maxspeed (maybe wait for maxspeed PR)
   if not (presence[LEFT_SIGN] or presence[CENTER_SIGN] or presence[RIGHT_SIGN]) then
-    if Set({ "path",
-      "cycleway",
-      "track",
-      "residential",
-      "unclassified",
-      "service",
-      "living_street",
-      "pedestrian",
-      "service",
-      "motorway_link",
-      "motorway",
-      "footway",
-      "steps" })[tags.highway] then
+    if JoinSets({ HighwayClasses, MinorRoadClasses, PathClasses })[tags.highway] then
       intoExcludeTable(object, "no infrastructure expected for highway type: " .. tags.highway)
       return
     elseif tags.motorroad or tags.expressway or tags.cyclestreet or tags.bicycle_road then

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -9,9 +9,9 @@ local function dataNo(tags)
 end
 
 -- for oneways we assume that the tag `cycleway=*` significates that there's one bike line on the left
--- TODO: this assumes right hand traffic (would be nice to have this as an option)
+-- TODO: this assumes right hand traffic (would be nice to specify this as an option)
 local function implicitOneWay(tags)
-  local result = tags.parent ~= nil and tags.prefix == 'cycleway' and tags.side == ''-- object is created from implicit case
+  local result = tags.parent ~= nil and tags.prefix == 'cycleway' and tags.side == '' -- object is created from implicit case
   result = result and tags.parent.oneway == 'yes' and tags.parent['oneway:bicycle'] ~= 'no' -- is oneway w/o bike exception
   result = result and tags.sign == LEFT_SIGN
   if result then

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -110,7 +110,7 @@ local function cyclewaySeparated(tags)
     result = result or tags.cycleway == "track" or tags.cycleway == "opposite_track"
     -- Case: Separate cycleway
     --    https://www.openstreetmap.org/way/989837901/
-    result = result or tags.bicycle == 'yes' or tags.bicycle == "designated" and (tags.foot == "no" or tags.foot == nil)
+    result = result or tags.bicycle == 'yes' or tags.bicycle == "designated" and (tags.foot == "no" or tags.foot == nil) -- maybe use foot ~= yes instead
   end
   if result then
     return "cyclewaySeparated"
@@ -121,6 +121,7 @@ local function cyclewayOnHighway(tags)
   -- Case: Cycleway identified via "lane"-tagging, which means it is part of the highway.
   --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dlane
   --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dopposite_lane
+  -- TODO: we should add shared_line https://wiki.openstreetmap.org/w/index.php?title=Tag:cycleway%3Dshared_lane&uselang=en
   if tags.highway == 'cycleway' and (tags.cycleway == "lane" or tags.cycleway == "opposite_lane") then
     return "cyclewayOnHighway"
   end

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -121,18 +121,10 @@ local function cyclewayOnHighway(tags)
   -- Case: Cycleway identified via "lane"-tagging, which means it is part of the highway.
   --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dlane
   --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dopposite_lane
-  local result = tags.highway == 'cycleway' and (tags.cycleway == "lane" or tags.cycleway == "opposite_lane")
+
+  -- https://wiki.openstreetmap.org/w/index.php?title=Tag:cycleway%3Dshared_lane&uselang=en
   if result then
     return "cyclewayOnHighway"
-  end
-end
-
-local function cyclewaySharedLane(tags)
-  -- Case: Cycleway identified via "shared_lane"-tagging, which means it is part of the highway.
-  -- https://wiki.openstreetmap.org/w/index.php?title=Tag:cycleway%3Dshared_lane&uselang=en
-  local result = tags.highway == 'cycleway' and tags.cycleway == "shared_lane"
-  if result then
-    return "cyclewaySharedLane"
   end
 end
 

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -121,9 +121,18 @@ local function cyclewayOnHighway(tags)
   -- Case: Cycleway identified via "lane"-tagging, which means it is part of the highway.
   --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dlane
   --    https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dopposite_lane
-  -- TODO: we should add shared_line https://wiki.openstreetmap.org/w/index.php?title=Tag:cycleway%3Dshared_lane&uselang=en
-  if tags.highway == 'cycleway' and (tags.cycleway == "lane" or tags.cycleway == "opposite_lane") then
+  local result = tags.highway == 'cycleway' and (tags.cycleway == "lane" or tags.cycleway == "opposite_lane")
+  if result then
     return "cyclewayOnHighway"
+  end
+end
+
+local function cyclewaySharedLane(tags)
+  -- Case: Cycleway identified via "shared_lane"-tagging, which means it is part of the highway.
+  -- https://wiki.openstreetmap.org/w/index.php?title=Tag:cycleway%3Dshared_lane&uselang=en
+  local result = tags.highway == 'cycleway' and tags.cycleway == "shared_lane"
+  if result then
+    return "cyclewaySharedLane"
   end
 end
 

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -11,7 +11,7 @@ end
 -- for oneways we assume that the tag `cycleway=*` significates that there's one bike line on the left
 -- TODO: this assumes right hand traffic (would be nice to have this as an option)
 local function implicitOneWay(tags)
-  local result = tags.parent ~= nil and tags['_projected_from'] == 'cycleway' -- object is created from implicit case
+  local result = tags.parent ~= nil and tags.prefix == 'cycleway' and tags.side == ''-- object is created from implicit case
   result = result and tags.parent.oneway == 'yes' and tags.parent['oneway:bicycle'] ~= 'no' -- is oneway w/o bike exception
   result = result and tags.sign == LEFT_SIGN
   if result then

--- a/app/process/bikelanes/transformations.lua
+++ b/app/process/bikelanes/transformations.lua
@@ -29,7 +29,7 @@ function GetTransformedObjects(tags, transformations)
   }
   tags.sign = 0
   local results = { tags }
-  if not StreetClasses[tags.highway] then
+  if PathClasses[tags.highway] then
     return results
   end
   for _, transformation in pairs(transformations) do

--- a/app/process/bikelanes/transformations.lua
+++ b/app/process/bikelanes/transformations.lua
@@ -29,6 +29,9 @@ function GetTransformedObjects(tags, transformations)
   }
   tags.sign = 0
   local results = { tags }
+  if not StreetClasses[tags.highway] then
+    return results
+  end
   for _, transformation in pairs(transformations) do
     for side, sign in pairs(sides) do
       if tags.highway ~= transformation.highway then

--- a/app/process/bikelanes/transformations.lua
+++ b/app/process/bikelanes/transformations.lua
@@ -1,12 +1,18 @@
--- unnest all tags from ["prefix:subtag"]=val -> ["subtag"]=val
-local function unnestTags(tags, prefix, dest)
+-- unnest all tags from ["prefix .. side:subtag"]=val -> ["subtag"]=val
+local function unnestTags(tags, prefix, side, dest)
   dest = dest or {}
   dest.parent = tags
+  local fullPrefix = prefix .. side
   for prefixedKey, val in pairs(tags) do
-    if prefixedKey ~= prefix and StartsWith(prefixedKey, prefix) then
-      -- offset of 2 due to 1-indexing and for removing the ':'
-      local key = string.sub(prefixedKey, string.len(prefix) + 2)
-      dest[key] = val
+    if StartsWith(prefixedKey, fullPrefix) then
+      dest.side = side
+      if prefixedKey == fullPrefix then -- self projection
+        dest[prefix] = val
+      else
+        -- offset of 2 due to 1-indexing and for removing the ':'
+        local key = string.sub(prefixedKey, string.len(fullPrefix) + 2)
+        dest[key] = val
+      end
     end
   end
   return dest
@@ -21,31 +27,28 @@ function GetTransformedObjects(tags, transformations)
     [":left"] = LEFT_SIGN,
     [":right"] = RIGHT_SIGN
   }
-  local results = {}
+  tags.sign = 0
+  local results = { tags }
   for _, transformation in pairs(transformations) do
     for side, sign in pairs(sides) do
-      local prefix = transformation.prefix
-      local newObj = {highway = transformation.highway, name = tags.name}
-      unnestTags(tags, prefix, newObj)
-      unnestTags(tags, prefix .. ":both", newObj)
-      -- this is the transformation:
-      local prefixedSide = prefix .. side
-      if tags.highway ~= transformation.highway then -- check if tag exist
-        unnestTags(tags, prefixedSide, newObj)
-        if tags[prefixedSide] ~= nil then
-          newObj[prefix] = tags[prefixedSide] -- self projection
+      if tags.highway ~= transformation.highway then
+        local prefix = transformation.prefix
+        local newObj = {
+          highway = transformation.highway,
+          name = tags.name,
+          prefix = prefix,
+          sign = sign
+        }
+        -- we look for tags with the following hirachy: `prefix` < `prefix:both` < `prefix:side`
+        -- thus a more specific tag will always overwrite a more general one
+        unnestTags(tags, prefix, '', newObj)
+        unnestTags(tags, prefix, ':both', newObj)
+        unnestTags(tags, prefix, side, newObj)
+        if newObj.side ~= nil then
+          if not transformation.filter or transformation.filter(newObj) then
+            table.insert(results, newObj)
+          end
         end
-        -- transformation meta data (some categories rely on this e.g. implicit oneway)
-        -- TODO: make this conditional on the result of unnestTags
-        newObj._projected_from = prefixedSide
-        newObj._projected_to = prefix
-
-        if not transformation.filter or transformation.filter(newObj) then
-          newObj.sign = sign
-          table.insert(results, newObj)
-        end
-
-
         -- DRAFT FOR LANES:
         -- if newObj.lanes == nil and false then
         --   -- TODO: this assumes right hand traffic (would be nice to have this as an option)

--- a/app/process/bikelanes/transformations.lua
+++ b/app/process/bikelanes/transformations.lua
@@ -18,45 +18,47 @@ CENTER_SIGN = 0
 RIGHT_SIGN = -1
 function GetTransformedObjects(tags, transformations)
   local sides = {
-    [":left"] = { LEFT_SIGN },
-    [":right"] = { RIGHT_SIGN },
-    [":both"] = { LEFT_SIGN, RIGHT_SIGN },
-    [""] = { LEFT_SIGN, RIGHT_SIGN },
+    [":left"] = LEFT_SIGN,
+    [":right"] = RIGHT_SIGN
   }
-  local transformedObjects = {}
+  local results = {}
   for _, transformation in pairs(transformations) do
-    for side, signs in pairs(sides) do
-      -- TODO: take :both as scelleton and overwrite with specific tags from :left or :right (maybe also from implicit both)
-      for _, sign in pairs(signs) do
-        -- this is the transformation:
-        local prefix = transformation.prefix
-        local prefixedSide = prefix .. side
-        if tags[prefixedSide] ~= nil and tags.highway ~= transformation.highway then -- check if tag exist
-          local transformedObj = unnestTags(tags, prefixedSide)
-          transformedObj.highway = transformation.highway
-          transformedObj.name = tags.name -- copy name
-          transformedObj[prefix] = tags[prefixedSide] -- self projection
-
-          -- transformation meta data (some categories rely on this e.g. implicit oneway)
-          transformedObj._projected_from = prefixedSide
-          transformedObj._projected_to = prefix
-          if not transformation.filter or transformation.filter(transformedObj) then
-            transformedObj.sign = sign
-            table.insert(transformedObjects, transformedObj)
-          end
-          if transformedObj.lanes == nil and false then
-            -- TODO: this assumes right hand traffic (would be nice to have this as an option)
-            if sign == RIGHT_SIGN then
-              transformedObj['cycleway:lanes'] = transformedObj['cycleway:lanes:forward']
-              transformedObj['bicycle:lanes'] = transformedObj['bicycle:lanes:forward']
-            elseif sign == LEFT_SIGN then
-              transformedObj['cycleway:lanes'] = transformedObj['cycleway:lanes:backward']
-              transformedObj['bicycle:lanes'] = transformedObj['bicycle:lanes:backward']
-            end
-          end
+    for side, sign in pairs(sides) do
+      local prefix = transformation.prefix
+      local newObj = {highway = transformation.highway, name = tags.name}
+      unnestTags(tags, prefix, newObj)
+      unnestTags(tags, prefix .. ":both", newObj)
+      -- this is the transformation:
+      local prefixedSide = prefix .. side
+      if tags.highway ~= transformation.highway then -- check if tag exist
+        unnestTags(tags, prefixedSide, newObj)
+        if tags[prefixedSide] ~= nil then
+          newObj[prefix] = tags[prefixedSide] -- self projection
         end
+        -- transformation meta data (some categories rely on this e.g. implicit oneway)
+        -- TODO: make this conditional on the result of unnestTags
+        newObj._projected_from = prefixedSide
+        newObj._projected_to = prefix
+
+        if not transformation.filter or transformation.filter(newObj) then
+          newObj.sign = sign
+          table.insert(results, newObj)
+        end
+
+
+        -- DRAFT FOR LANES:
+        -- if newObj.lanes == nil and false then
+        --   -- TODO: this assumes right hand traffic (would be nice to have this as an option)
+        --   if sign == RIGHT_SIGN then
+        --     transformedObj['cycleway:lanes'] = transformedObj['cycleway:lanes:forward']
+        --     transformedObj['bicycle:lanes'] = transformedObj['bicycle:lanes:forward']
+        --   elseif sign == LEFT_SIGN then
+        --     transformedObj['cycleway:lanes'] = transformedObj['cycleway:lanes:backward']
+        --     transformedObj['bicycle:lanes'] = transformedObj['bicycle:lanes:backward']
+        --   end
+        -- end
       end
     end
   end
-  return transformedObjects
+  return results
 end

--- a/app/process/helper/JoinSets.lua
+++ b/app/process/helper/JoinSets.lua
@@ -1,6 +1,7 @@
-function JoinSets(a, b, dest)
+function JoinSets(sets, dest)
   dest = dest or {}
-  for k, _ in pairs(a) do dest[k] = true end
-  for k, _ in pairs(b) do dest[k] = true end
+  for _, set in pairs(sets) do
+    for k, _ in pairs(set) do dest[k] = true end
+  end
   return dest
 end

--- a/app/process/helper/JoinSets.lua
+++ b/app/process/helper/JoinSets.lua
@@ -1,0 +1,6 @@
+function JoinSets(a, b, dest)
+  dest = dest or {}
+  for k, _ in pairs(a) do dest[k] = true end
+  for k, _ in pairs(b) do dest[k] = true end
+  return dest
+end

--- a/app/process/lit/lit.lua
+++ b/app/process/lit/lit.lua
@@ -45,7 +45,7 @@ local table = osm2pgsql.define_table({
 function osm2pgsql.process_way(object)
   if not object.tags.highway then return end
 
-  local allowed_highways = JoinSets({StreetClasses, PathClasses})
+  local allowed_highways = JoinSets({HighwayClasses, MajorRoadClasses, MinorRoadClasses, PathClasses})
   -- values that we would allow, but skip here:
   -- "construction", "planned", "proposed", "platform" (Haltestellen)
   if not allowed_highways[object.tags.highway] then return end

--- a/app/process/lit/lit.lua
+++ b/app/process/lit/lit.lua
@@ -4,6 +4,7 @@ require("FilterTags")
 require("ToNumber")
 -- require("PrintTable")
 require("MergeArray")
+require("JoinSets")
 require("Metadata")
 require("HighwayClasses")
 require("ExcludeHighways")
@@ -44,10 +45,10 @@ local table = osm2pgsql.define_table({
 function osm2pgsql.process_way(object)
   if not object.tags.highway then return end
 
-  local allowed_values = HighwayClasses
+  local allowed_highways = JoinSets(StreetClasses, PathClasses)
   -- values that we would allow, but skip here:
   -- "construction", "planned", "proposed", "platform" (Haltestellen)
-  if not allowed_values[object.tags.highway] then return end
+  if not allowed_highways[object.tags.highway] then return end
   if ExcludeHighways(object.tags) or ExcludeByWidth(object.tags, 2.1) then
     return
   end

--- a/app/process/lit/lit.lua
+++ b/app/process/lit/lit.lua
@@ -45,7 +45,7 @@ local table = osm2pgsql.define_table({
 function osm2pgsql.process_way(object)
   if not object.tags.highway then return end
 
-  local allowed_highways = JoinSets(StreetClasses, PathClasses)
+  local allowed_highways = JoinSets({StreetClasses, PathClasses})
   -- values that we would allow, but skip here:
   -- "construction", "planned", "proposed", "platform" (Haltestellen)
   if not allowed_highways[object.tags.highway] then return end

--- a/app/process/roadClassification.lua
+++ b/app/process/roadClassification.lua
@@ -6,6 +6,7 @@ require("ToNumber")
 require("MergeArray")
 require("Metadata")
 require("HighwayClasses")
+require("JoinSets")
 require("ExcludeHighways")
 require("ExcludeByWidth")
 
@@ -32,11 +33,11 @@ local excludeTable = osm2pgsql.define_table({
 function osm2pgsql.process_way(object)
   if not object.tags.highway then return end
 
-  local allowed_values = HighwayClasses
+  local allowed_highways = JoinSets(StreetClasses, PathClasses)
   -- values that we would allow, but skip here:
   -- "construction", "planned", "proposed", "platform" (Haltestellen),
   -- "rest_area" (https://wiki.openstreetmap.org/wiki/DE:Tag:highway=rest%20area)
-  if not allowed_values[object.tags.highway] then return end
+  if not allowed_highways[object.tags.highway] then return end
 
 
   --TODO: exit here

--- a/app/process/roadClassification.lua
+++ b/app/process/roadClassification.lua
@@ -33,7 +33,7 @@ local excludeTable = osm2pgsql.define_table({
 function osm2pgsql.process_way(object)
   if not object.tags.highway then return end
 
-  local allowed_highways = JoinSets(StreetClasses, PathClasses)
+  local allowed_highways = JoinSets({StreetClasses, PathClasses})
   -- values that we would allow, but skip here:
   -- "construction", "planned", "proposed", "platform" (Haltestellen),
   -- "rest_area" (https://wiki.openstreetmap.org/wiki/DE:Tag:highway=rest%20area)

--- a/app/process/roadClassification.lua
+++ b/app/process/roadClassification.lua
@@ -33,7 +33,7 @@ local excludeTable = osm2pgsql.define_table({
 function osm2pgsql.process_way(object)
   if not object.tags.highway then return end
 
-  local allowed_highways = JoinSets({StreetClasses, PathClasses})
+  local allowed_highways = JoinSets({HighwayClasses, MajorRoadClasses, MinorRoadClasses, PathClasses})
   -- values that we would allow, but skip here:
   -- "construction", "planned", "proposed", "platform" (Haltestellen),
   -- "rest_area" (https://wiki.openstreetmap.org/wiki/DE:Tag:highway=rest%20area)

--- a/app/process/shared/HighwayClasses.lua
+++ b/app/process/shared/HighwayClasses.lua
@@ -1,6 +1,6 @@
 -- https://wiki.openstreetmap.org/wiki/DE:Key:highway
 -- https://wiki.openstreetmap.org/wiki/Attribuierung_von_Stra%C3%9Fen_in_Deutschland
-HighwayClasses = Set({
+StreetClasses = Set({
   -- "*_link" bedeutet "Autobahnzubringer", "Anschlussstelle", "Auf- / Abfahrt"
   "motorway", "motorway_link", -- "Autobahn"
   "trunk", "trunk_link", -- "Autobahnähnliche Straße", "Schnellstraßen" (those have motorroad=yes)
@@ -12,6 +12,9 @@ HighwayClasses = Set({
   "road", -- Ohne Klassifizierung
   "living_street", -- "Verkehrsberuhigter Bereich", "Spielstraße" traffic_sign=325.1 (Beginn), 326 (Ende)
   "service", -- "Zufahrtswege", aber auch "Grundstückszufahrt", Wege auf Parkplätzen, "Drive trough", "Gassen", "Feuerwehzufahrt"
+})
+
+PathClasses = Set({
   "pedestrian", -- "Fußgängerzone"
   "track", -- "Wirtschaftswege", "Wald- und Feldwege"
   "path",

--- a/app/process/shared/HighwayClasses.lua
+++ b/app/process/shared/HighwayClasses.lua
@@ -1,5 +1,8 @@
 -- https://wiki.openstreetmap.org/wiki/DE:Key:highway
 -- https://wiki.openstreetmap.org/wiki/Attribuierung_von_Stra%C3%9Fen_in_Deutschland
+-- We keep the different highway classes separate so we can use them for filtering
+-- to combine them use the function JoinSets in the ~/process/helper/JoinSets
+
 StreetClasses = Set({
   -- "*_link" bedeutet "Autobahnzubringer", "Anschlussstelle", "Auf- / Abfahrt"
   "motorway", "motorway_link", -- "Autobahn"

--- a/app/process/shared/HighwayClasses.lua
+++ b/app/process/shared/HighwayClasses.lua
@@ -3,13 +3,19 @@
 -- We keep the different highway classes separate so we can use them for filtering
 -- to combine them use the function JoinSets in the ~/process/helper/JoinSets
 
-StreetClasses = Set({
-  -- "*_link" bedeutet "Autobahnzubringer", "Anschlussstelle", "Auf- / Abfahrt"
+-- "*_link" bedeutet "Autobahnzubringer", "Anschlussstelle", "Auf- / Abfahrt"
+HighwayClasses = Set({
   "motorway", "motorway_link", -- "Autobahn"
   "trunk", "trunk_link", -- "Autobahnähnliche Straße", "Schnellstraßen" (those have motorroad=yes)
+})
+
+MajorRoadClasses = Set({
   "primary", "primary_link", -- "Bundesstraßen" (B XXX)
   "secondary", "secondary_link", -- "Landesstraße" (L XXX)
   "tertiary", "tertiary_link", -- "Kreisstraße", "Gemeindeverbindungsstraße", "Innerstädtische Vorfahrtstraßen mit Durchfahrtscharakter"
+})
+
+MinorRoadClasses = Set({
   "unclassified", -- "Nebenstraßen", "Gemeindestraße mit Verbindungscharakter"
   "residential", -- "Straße an und in Wohngebieten"
   "road", -- Ohne Klassifizierung


### PR DESCRIPTION
This PR implements a kind of inheritance scheme for the objects that get synthesized from the center line. 
Even though the tags should be consistent we define a hierarchy s.t. more specific tags will all ways overwrite more general ones in the case of ambiguities.  E.g. an object created from tags `cycleway:both = no` and `cycleway:right = lane` would include the latter.
Namely the hierarchy is  `cycleway: left | right` > `cycleway:both` > `cycleway`

Example of the general functionality: for an object with the tags `cycleway:both = lane` and `cycleway:right:width =  1.4`  the transformation creates an object with the following tags:
`cycleway = lane`
`width = 1.4`
`prefix = cycleway` (depends on the particular transformation)
`side = right` (this relates to the most specific tag that was applied)

The `_projected_from` and `_projected_to`  attributes are removed, because the same information is carried in the `prefix` and `side` attribtues.

Releated to https://github.com/FixMyBerlin/private-issues/issues/318

@tordans 