### PR TITLE
Refinement of the presence data set

### DIFF
--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -157,6 +157,16 @@ function osm2pgsql.process_way(object)
   -- replace all nil values with 'missing'
   for _, side in pairs(SIDES) do presence[side] = presence[side] or "missing" end
 
+  allowed_tags = Set({
+    'name',
+    'highway',
+    'self',
+    'left',
+    'right',
+    'oneway',
+    'dual_carriageway'
+  })
+  FilterTags(tags, allowed_tags)
   presenceTable:insert({
     tags = tags,
     geom = object:as_linestring(),

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -153,6 +153,12 @@ function osm2pgsql.process_way(object)
   -- We would have to do this in a separate processing step or wait for length() data to be available in LUA
   -- MORE: osm-scripts-Repo => utils/Highways-BicycleWayData/filter/radwegVerbindungsstueck.ts
 
+  if presence[CENTER_SIGN] then
+    -- TODO: here we could check for collissions between center line and self
+    presence[LEFT_SIGN] = presence[LEFT_SIGN] or 'not_expected'
+    presence[RIGHT_SIGN] = presence[RIGHT_SIGN] or 'not_expected'
+  end
+
   presenceTable:insert({
     tags = tags,
     geom = object:as_linestring(),

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -141,7 +141,7 @@ function osm2pgsql.process_way(object)
     not_expected.service = nil
     if not_expected[tags.highway] then
       -- enough to set the center value (see last if at end of function)
-      presence[CENTER_SIGN] = 'not_expected'
+      presence[CENTER_SIGN] = NOT_EXPECTED
     elseif not MajorRoadClasses[tags.highway] then
       IntoExcludeTable(excludeTable, object, "no infrastructure expected for highway type: " .. tags.highway)
       return
@@ -160,8 +160,8 @@ function osm2pgsql.process_way(object)
 
   if presence[CENTER_SIGN] then
     -- TODO: here we could check for collissions between center line and self
-    presence[LEFT_SIGN] = presence[LEFT_SIGN] or 'not_expected'
-    presence[RIGHT_SIGN] = presence[RIGHT_SIGN] or 'not_expected'
+    presence[LEFT_SIGN] = presence[LEFT_SIGN] or NOT_EXPECTED
+    presence[RIGHT_SIGN] = presence[RIGHT_SIGN] or NOT_EXPECTED
   end
 
   presenceTable:insert({

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -154,12 +154,9 @@ function osm2pgsql.process_way(object)
     end
   end
 
-  -- TODO excludeTable: For ZES, we exclude "Verbindungsstücke", especially for the "cyclewayAlone" case
-  -- We would have to do this in a separate processing step or wait for length() data to be available in LUA
-  -- MORE: osm-scripts-Repo => utils/Highways-BicycleWayData/filter/radwegVerbindungsstueck.ts
-
   -- replace all nil values with 'missing'
   for _, side in pairs(SIDES) do presence[side] = presence[side] or "missing" end
+
   presenceTable:insert({
     tags = tags,
     geom = object:as_linestring(),

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -86,6 +86,7 @@ function osm2pgsql.process_way(object)
   end
 
   local tags = object.tags
+  local meta = Metadata(object)
 
   -- transformations
   local footwayTransformation = {
@@ -124,7 +125,7 @@ function osm2pgsql.process_way(object)
         categoryTable:insert({
           category = category,
           tags = cycleway,
-          meta = Metadata(object),
+          meta = meta,
           geom = object:as_linestring(),
           _offset = cycleway.offset
         })
@@ -173,5 +174,7 @@ function osm2pgsql.process_way(object)
     left = presence[LEFT_SIGN],
     self = presence[CENTER_SIGN],
     right = presence[RIGHT_SIGN],
+    meta = meta,
   })
+
 end

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -137,15 +137,20 @@ function osm2pgsql.process_way(object)
   -- Filter ways where we dont expect bicycle infrastructure
   -- TODO: filter on surface and traffic zone and maxspeed (maybe wait for maxspeed PR)
   if not (presence[LEFT_SIGN] or presence[CENTER_SIGN] or presence[RIGHT_SIGN]) then
-    if JoinSets({ HighwayClasses, MinorRoadClasses, PathClasses })[tags.highway] then
+    local not_expected = MinorRoadClasses
+    not_expected.service = nil
+    if not_expected[tags.highway] then
+      -- enough to set the center value (see last if at end of function)
+      presence[CENTER_SIGN] = 'not_expected'
+    elseif not MajorRoadClasses[tags.highway] then
       IntoExcludeTable(excludeTable, object, "no infrastructure expected for highway type: " .. tags.highway)
       return
-    elseif tags.motorroad or tags.expressway or tags.cyclestreet or tags.bicycle_road then
-      IntoExcludeTable(excludeTable, object, "no (extra) infrastructure expected for motorroad, express way and cycle streets")
+    elseif tags.motorroad or tags.expressway then
+      IntoExcludeTable(excludeTable, object, "no infrastructure expected for motorroad and express way")
       return
-      -- elseif tags.maxspeed and tags.maxspeed <= 20 then
-      --   intoExcludeTable(object, "no infrastructure expected for max speed <= 20 kmh")
-      --   return
+    -- elseif tags.maxspeed and tags.maxspeed <= 20 then
+    --   intoExcludeTable(object, "no infrastructure expected for max speed <= 20 kmh")
+    --   return
     end
   end
 

--- a/app/process/bikelanes/categories.lua
+++ b/app/process/bikelanes/categories.lua
@@ -1,4 +1,5 @@
 -- PREDICATES FOR EACH CATEGORY:
+NOT_EXPECTED = 'not_expected'
 
 -- this category is for the explicit absence of bike infrastrucute
 -- TODO: split into `no` or `separate`
@@ -15,9 +16,9 @@ local function implicitOneWay(tags)
       tags.side == '' -- object is created from implicit case
   result = result and tags.parent.oneway == 'yes' and
       tags.parent['oneway:bicycle'] ~= 'no' -- is oneway w/o bike exception
-  result = result and tags.sign == LEFT_SIGN
+  result = result and tags.sign == LEFT_SIGN -- is the left side object
   if result then
-    return 'not_expected'
+    return NOT_EXPECTED
   end
 end
 

--- a/app/process/bikelanes/transformations.lua
+++ b/app/process/bikelanes/transformations.lua
@@ -22,6 +22,7 @@ end
 LEFT_SIGN = 1
 CENTER_SIGN = 0
 RIGHT_SIGN = -1
+SIDES = {LEFT_SIGN, CENTER_SIGN, RIGHT_SIGN}
 function GetTransformedObjects(tags, transformations)
   local sides = {
     [":left"] = LEFT_SIGN,

--- a/app/process/lit/lit.lua
+++ b/app/process/lit/lit.lua
@@ -57,7 +57,11 @@ function osm2pgsql.process_way(object)
 
   -- Categorize the data in three groups: "lit", "unlit", "special"
   local category = nil
-  if (object.tags.lit) then
+  if object.tags.lit == nil then
+
+    object.tags.is_present = false
+  else
+    object.tags.is_present = true
     category = "special"
     if (object.tags.lit == "yes") then
       category = "lit"
@@ -65,13 +69,6 @@ function osm2pgsql.process_way(object)
     if (object.tags.lit == "no") then
       category = "unlit"
     end
-  end
-
-  -- Presence of data
-  if (object.tags.lit) then
-    object.tags.is_present = true
-  else
-    object.tags.is_present = false
   end
 
   -- Freshness of data


### PR DESCRIPTION
This PR is the latest iteration on the presence data set.
It includes the following changes:
- if either `center` has category or both `left` and `right` have categories  -> we set the other attributes to `not_expected`
- minor roads with no categories are included in the presence data, but with `center | left | right = not_expected` 
- meta data is added
- tags are filtered

Ping https://github.com/FixMyBerlin/private-issues/issues/455