### PR TITLE
License in data exports

### DIFF
--- a/api/INIT_FUNCTIONS.sql
+++ b/api/INIT_FUNCTIONS.sql
@@ -5,12 +5,14 @@ CREATE OR REPLACE FUNCTION public.{func_name}(minlon double precision, minlat do
 AS $function$
 	SELECT json_build_object(
 	    'type',     'FeatureCollection',
+      'license', 'ODbL 1.0, https://opendatacommons.org/licenses/odbl/',
+      'attribution', 'OpenStreetMap, https://www.openstreetmap.org/copyright',
 	    'features', json_agg(features.feature)
 	)
 	FROM (
 	  SELECT jsonb_build_object(
 	    'type',       'Feature',
-	    'geometry',   ST_AsGeoJSON(ST_Transform(geom,4326))::jsonb,
+	    'geometry',   ST_AsGeoJSON(ST_Transform(geom, 4326))::jsonb,
 	    'properties', to_jsonb(inputs) - 'geom' || inputs.tags
 	  ) AS feature
 	  FROM (

--- a/api/main.py
+++ b/api/main.py
@@ -45,7 +45,7 @@ def export_region(response: Response, type_name: str, minlon: float= 13.3, minla
     response.headers["Content-Disposition"] = 'attachment; filename="'+type_name+'.geojson"'
     response.headers["Content-Type"] = 'application/geo+json'
 
-    statement = sql.SQL("SELECT {table_name}.*, license.* FROM {table_name} (%s, %s, %s, %s), license;").format(table_name=sql.Identifier(export_geojson_function_from_type[type_name]))
+    statement = sql.SQL("SELECT * FROM {table_name} (%s, %s, %s, %s);").format(table_name=sql.Identifier(export_geojson_function_from_type[type_name]))
     cur.execute(statement, ( minlon, minlat, maxlon, maxlat) )
     return cur.fetchone()[0]
 

--- a/api/main.py
+++ b/api/main.py
@@ -45,7 +45,7 @@ def export_region(response: Response, type_name: str, minlon: float= 13.3, minla
     response.headers["Content-Disposition"] = 'attachment; filename="'+type_name+'.geojson"'
     response.headers["Content-Type"] = 'application/geo+json'
 
-    statement = sql.SQL("SELECT * FROM {table_name} (%s, %s, %s, %s);").format(table_name=sql.Identifier(export_geojson_function_from_type[type_name]))
+    statement = sql.SQL("SELECT {table_name}.*, license.* FROM {table_name} (%s, %s, %s, %s), license;").format(table_name=sql.Identifier(export_geojson_function_from_type[type_name]))
     cur.execute(statement, ( minlon, minlat, maxlon, maxlat) )
     return cur.fetchone()[0]
 

--- a/api/prestart.sh
+++ b/api/prestart.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # echo "Start creating export functions and verification tables"
-# python init_db.py
+python init_db.py


### PR DESCRIPTION
This PR adds a license to all the .geojson exports of the backend. The values are attributes of the FeatureCollection, thus exist one time per file. This means that the are not officially part of the geojson schema but included as a [foreign members](https://stevage.github.io/geojson-spec/#section-6.1).

@tordans @ohrie 