### PR TITLE
Fix: extend `not expected`

### DIFF
--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -141,10 +141,10 @@ function osm2pgsql.process_way(object)
     end
   end
 
+  -- Bellow is presence logic
   -- Filter ways where we dont expect bicycle infrastructure
   -- TODO: filter on surface and traffic zone and maxspeed (maybe wait for maxspeed PR)
-  local data_complete = presence[CENTER_SIGN] or (presence[RIGHT_SIGN] and presence[LEFT_SIGN])
-  if (MinorRoadClasses[tags.highway] and tags.highway ~= 'service') or data_complete then
+  if (MinorRoadClasses[tags.highway] and tags.highway ~= 'service') or presence[CENTER_SIGN] then
     -- set the nil values to 'not_expected', for all minor roads and complete data
     for _, side in pairs(SIDES) do presence[side] = presence[side] or NOT_EXPECTED end
   elseif not (presence[CENTER_SIGN] or presence[RIGHT_SIGN] or presence[LEFT_SIGN]) then
@@ -153,12 +153,16 @@ function osm2pgsql.process_way(object)
       return
     elseif tags.motorroad or tags.expressway then
       IntoExcludeTable(excludeTable, object, "no infrastructure expected for motorroad and express way")
-
       return
       -- elseif tags.maxspeed and tags.maxspeed <= 20 then
       --   intoExcludeTable(object, "no infrastructure expected for max speed <= 20 kmh")
       --   return
     end
+  elseif (presence[RIGHT_SIGN] or presence[LEFT_SIGN]) then
+    presence[CENTER_SIGN] = presence[CENTER_SIGN] or NOT_EXPECTED
+  end
+  if tags.oneway == 'yes' and tags['oneway:bicycle'] ~= 'no' then
+    presence[LEFT_SIGN] = presence[LEFT_SIGN] or NOT_EXPECTED
   end
 
   -- replace all nil values with 'missing'
@@ -173,7 +177,6 @@ function osm2pgsql.process_way(object)
     'oneway',
     'dual_carriageway',
   })
-
   FilterTags(tags, allowed_tags_presence)
   presenceTable:insert({
     tags = tags,

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -33,6 +33,7 @@ local presenceTable = osm2pgsql.define_table({
     { column = 'left',  type = 'text' },
     { column = 'self',  type = 'text' },
     { column = 'right', type = 'text' },
+    { column = 'meta',  type = 'jsonb' }
   }
 })
 

--- a/app/process/bikelanes/bikelanes.lua
+++ b/app/process/bikelanes/bikelanes.lua
@@ -141,7 +141,7 @@ function osm2pgsql.process_way(object)
     end
   end
 
-  -- Bellow is presence logic
+  -- Below is presence logic
   -- Filter ways where we dont expect bicycle infrastructure
   -- TODO: filter on surface and traffic zone and maxspeed (maybe wait for maxspeed PR)
   if (MinorRoadClasses[tags.highway] and tags.highway ~= 'service') or presence[CENTER_SIGN] then

--- a/app/process/bikelanes/transformations.lua
+++ b/app/process/bikelanes/transformations.lua
@@ -10,11 +10,11 @@ local function unnestTags(tags, prefix, side, dest)
         dest[prefix] = val
         dest.side = side
       else
+        -- offset of 2 due to 1-indexing and for removing the ':'
         local prefixlessKey = string.sub(key, prefixLen + 2)
         local infix = string.match(prefixlessKey, '[^:]*')
-        -- avoid projecting sided tags in the implicit case
-        if not Set({ 'left', 'right', 'both' })[infix] then
-          -- offset of 2 due to 1-indexing and for removing the ':'
+        if side ~= '' or not Set({ 'left', 'right', 'both' })[infix] then
+          -- avoid projecting sided tags in the implicit case
           dest[prefixlessKey] = val
           dest.side = side
         end


### PR DESCRIPTION
This PR extends the `not expected` category in two cases:
- if `left` or `right` has a category `self` will be set to `not expected`
- if the way is `oneway = yes` and `bicycle:oneway ~= no` we'll set `left` to `not expected`