### PR TITLE
Infer max speed from landuse

### DIFF
--- a/app/process/maxspeed/maxspeed.sql
+++ b/app/process/maxspeed/maxspeed.sql
@@ -16,18 +16,23 @@
 -- make a union of the filter geometries
 -- check intersections or inclusion for ways that lack maxspeed e.g. those in _maxspeed_missing
 -- add these ways with a constant maxspeed and `present=false` into maxspeed table
-SELECT ST_Transform(geom, 25833) from landuse where tags->>'landuse' = 'residential';
+-- SELECT ST_Transform(geom, 25833) from landuse where tags->>'landuse' = 'residential';
 
-INSERT INTO "maxspeed_transformed"
-  SELECT   maxspeed.*
-  FROM "fromTo_landuse" as landuse, "_maxspeed_missing" as maxspeed
-  WHERE ST_Intersects(maxspeed.geom::geometry , ST_Expand(landuse.geom, 10)::geometry);
+-- UPDATE "maxspeed_transformed"
+--   SELECT   maxspeed.*
+--   FROM "fromTo_landuse" as landuse, "_maxspeed_missing" as maxspeed
+--   WHERE ST_Intersects(maxspeed.geom::geometry , ST_Expand(landuse.geom, 10)::geometry);
 
 -- UPDATE "maxspeed_transformed" SET "_maxspeed_source" = 'infereed from landuse';
 
-update "maxspeed_transformed"
-set  tags = jsonb_set(tags, '{_maxspeed_source}','"infereed from landuse"');
+update "_maxspeed_missing" as maxpseed
+set tags = jsonb_set(tags, '{_maxspeed_source}','"infereed from landuse"')
+WHERE ST_Intersects(maxspeed.geom::geometry , ST_Expand(landuse.geom, 10)::geometry);
 
-update "maxspeed_transformed"
-set  tags = jsonb_insert(tags, '{maxspeed}','"add maxspeed:source=DE:urban to way"');
+update "_maxspeed_missing" as maxpseed
+set  tags = jsonb_insert(tags, '{maxspeed}','"add maxspeed:source=DE:urban to way"')
+WHERE ST_Intersects(maxspeed.geom::geometry , ST_Expand(landuse.geom, 10)::geometry);
+
+-- TODO copy to maxspeed main table
+
 

--- a/app/run-4-process.sh
+++ b/app/run-4-process.sh
@@ -58,7 +58,7 @@ psql -q -f "${PROCESS_DIR}roadClassification.sql"
 
 echo "\e[1m\e[7m PROCESS – Topic: maxspeed \e[27m\e[21m"
 ${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}maxspeed/maxspeed.lua ${OSM_FILTERED_FILE}
-# psql -q -f "${PROCESS_DIR}maxspeed/maxspeed.sql"
+psql -q -f "${PROCESS_DIR}maxspeed/maxspeed.sql"
 
 
 # echo "\e[1m\e[7m PROCESS – Topic: parking \e[27m\e[21m"


### PR DESCRIPTION
This PR adds an experimental feature in which we try to infer max speed values based on there distance to certain `landuse` objects.

The geometric selection can be viewed in the `_maxspeed_missing` table.