### PR TITLE
Flat properties in GeoJSON exports

### DIFF
--- a/api/INIT_FUNCTIONS.sql
+++ b/api/INIT_FUNCTIONS.sql
@@ -13,7 +13,7 @@ AS $function$
 	  SELECT jsonb_build_object(
 	    'type',       'Feature',
 	    'geometry',   ST_AsGeoJSON(ST_Transform(geom, 4326))::jsonb,
-	    'properties', to_jsonb(inputs) - 'geom' || inputs.tags
+	    'properties', inputs.meta || inputs.tags
 	  ) AS feature
 	  FROM (
 	    SELECT * from "{table_name}"

--- a/api/INIT_FUNCTIONS.sql
+++ b/api/INIT_FUNCTIONS.sql
@@ -4,10 +4,10 @@ CREATE OR REPLACE FUNCTION public.{func_name}(minlon double precision, minlat do
  LANGUAGE sql
 AS $function$
 	SELECT json_build_object(
-	    'type',     'FeatureCollection',
-      'license', 'ODbL 1.0, https://opendatacommons.org/licenses/odbl/',
-      'attribution', 'OpenStreetMap, https://www.openstreetmap.org/copyright; Radverkehrsatlas.de',
-	    'features', json_agg(features.feature)
+	    'type',         'FeatureCollection',
+      'license',      'ODbL 1.0, https://opendatacommons.org/licenses/odbl/',
+      'attribution',  'OpenStreetMap, https://www.openstreetmap.org/copyright; Radverkehrsatlas.de',
+	    'features',     json_agg(features.feature)
 	)
 	FROM (
 	  SELECT jsonb_build_object(

--- a/api/INIT_FUNCTIONS.sql
+++ b/api/INIT_FUNCTIONS.sql
@@ -13,7 +13,8 @@ AS $function$
 	  SELECT jsonb_build_object(
 	    'type',       'Feature',
 	    'geometry',   ST_AsGeoJSON(ST_Transform(geom, 4326))::jsonb,
-	    'properties', inputs.meta || inputs.tags
+      'id',         inputs.osm_id,
+	    'properties', jsonb_build_object('type', inputs.osm_type) || inputs.meta || inputs.tags
 	  ) AS feature
 	  FROM (
 	    SELECT * from "{table_name}"

--- a/api/db_configuration.py
+++ b/api/db_configuration.py
@@ -17,8 +17,8 @@ export_geojson_function_from_type = {
   "poiClassification":  "atlas_export_geojson_shops",
   "publicTransport":    "atlas_export_geojson_publictransport",
   "roadClassification": "atlas_export_geojson_roadtypes",
-  "barrierLines":       "atlas_export_geojson_barrierLines",
-  "barrierAreas":       "atlas_export_geojson_barrierAreas"
+  "barrierLines":       "atlas_export_geojson_barrierlines",
+  "barrierAreas":       "atlas_export_geojson_barrierareas"
 }
 
 # main.py: Used as an allow list to guard the /verify/* API

--- a/app/process/boundaries.lua
+++ b/app/process/boundaries.lua
@@ -2,6 +2,7 @@ local srid = 4326
 
 -- TODO: This is the only table that does not use jsonb to store the tags.
 -- Which means it breaks when we try to use our export script.
+-- It also lacks a jsonb meta column.
 -- See also db_configuration.py.
 
 local table = osm2pgsql.define_area_table('boundaries', {


### PR DESCRIPTION
This PR changes the geoJSON exports s.t. the properties are always a join of the `meta` and `tags` dictionaries.
Through that we have all the information on the same level and remove the nested structure.
This in turn requires to always have `meta` and `tags` columns which both have to be of type `jsonb`.

It also fixes a bug in the barrier exports.

Related to https://github.com/FixMyBerlin/private-issues/issues/583