### PR TITLE
Optimize building dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ The workflow is…
 
 2. Rebuild and restart everything
 
+   ```npm run dev````
+
+   _OR_
+
    ```sh
    docker compose --profile osm_processing build && docker compose --profile osm_processing up
    ```

--- a/api/db_configuration.py
+++ b/api/db_configuration.py
@@ -8,8 +8,8 @@ export_geojson_function_from_type = {
   "bikelanes_verified": "atlas_export_geojson_bikelanes_verified",
   "bikelanes":          "atlas_export_geojson_bikelanes",
   "bikelanesPresence":  "atlas_export_geojson_bikelanesPresence",
-  # "boundaries":         "atlas_export_geojson_boundaries", # does not work; we need to align the way we store the tags with the other table (it's) the only one that does not use jsonb
-  "buildings":          "atlas_export_geojson_buildings",
+  # "boundaries":         "atlas_export_geojson_boundaries", # does not work; we need to align the way we store the tags with the other table
+  # "buildings":          "atlas_export_geojson_buildings", # same as above but due to clustering of connected buildings there is no good way to preseve (merge) tags
   "education":          "atlas_export_geojson_education",
   "landuse":            "atlas_export_geojson_landuse",
   "lit_verified":       "atlas_export_geojson_lit_verified",

--- a/app/process/buildings/buildings.lua
+++ b/app/process/buildings/buildings.lua
@@ -6,7 +6,7 @@ require("Metadata")
 require("InferAddress")
 
 local table = osm2pgsql.define_table({
-  name = 'buildings',
+  name = '_buildings_temp',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
     { column = 'tags', type = 'jsonb' },

--- a/app/process/buildings/buildings.lua
+++ b/app/process/buildings/buildings.lua
@@ -20,6 +20,7 @@ local function ExitProcessing(object)
     return true
   end
 
+  -- We include all buildings … but filter small once in SQL
   -- Docs: https://wiki.openstreetmap.org/wiki/Key:buildings
   -- local allowed_values = Set({
   --   "city",
@@ -31,20 +32,20 @@ local function ExitProcessing(object)
   return false
 end
 
-local function processTags(tags)
-  local allowed_tags = Set({ "building", AddressKeys })
-  FilterTags(tags, allowed_tags)
-end
+-- local function processTags(tags)
+--   local allowed_tags = Set({ "building", AddressKeys })
+--   FilterTags(tags, allowed_tags)
+-- end
 
 function osm2pgsql.process_way(object)
   if ExitProcessing(object) then return end
   if not object.is_closed then return end
 
-  processTags(object.tags)
+  -- processTags(object.tags)
 
   table:insert({
-    tags = object.tags,
-    meta = Metadata(object),
+    -- tags = object.tags, -- we only keep the geometry for this dataset
+    -- meta = Metadata(object), -- we only keep the geometry for this dataset
     geom = object:as_multipolygon()
   })
 end
@@ -53,10 +54,11 @@ function osm2pgsql.process_relation(object)
   if ExitProcessing(object) then return end
   if not object.tags.type == 'multipolygon' then return end
 
-  processTags(object.tags)
+  -- processTags(object.tags)
+
   table:insert({
-    tags = object.tags,
-    meta = Metadata(object),
+    -- tags = object.tags, -- we only keep the geometry for this dataset
+    -- meta = Metadata(object), -- we only keep the geometry for this dataset
     geom = object:as_multipolygon()
   })
 end

--- a/app/process/buildings/buildings.sql
+++ b/app/process/buildings/buildings.sql
@@ -5,3 +5,5 @@ SELECT (unnest(st_clusterintersecting(geom))) AS geom INTO buildings FROM _build
 UPDATE buildings SET geom = st_multi(st_unaryunion(geom));
 -- copy results into final table and set CRS (couldn't find a way to infer the CRS)
 ALTER TABLE buildings ALTER COLUMN geom TYPE geometry (MultiPolygon, 3857);
+-- delete small buildings
+DELETE FROM buildings WHERE ST_Area(geom) < 20;

--- a/app/process/buildings/buildings.sql
+++ b/app/process/buildings/buildings.sql
@@ -1,9 +1,13 @@
-DROP TABLE buildings;
+DROP TABLE IF EXISTS buildings;
+
 -- cluster all intersecting buildings
 SELECT (unnest(st_clusterintersecting(geom))) AS geom INTO buildings FROM _buildings_temp;
+
 -- join clusters and convert to multi polygons
 UPDATE buildings SET geom = st_multi(st_unaryunion(geom));
+
 -- copy results into final table and set CRS (couldn't find a way to infer the CRS)
 ALTER TABLE buildings ALTER COLUMN geom TYPE geometry (MultiPolygon, 3857);
+
 -- delete small buildings
 DELETE FROM buildings WHERE ST_Area(geom) < 20;

--- a/app/process/buildings/buildings.sql
+++ b/app/process/buildings/buildings.sql
@@ -6,8 +6,9 @@ SELECT (unnest(st_clusterintersecting(geom))) AS geom INTO buildings FROM _build
 -- join clusters and convert to multi polygons
 UPDATE buildings SET geom = st_multi(st_unaryunion(geom));
 
--- copy results into final table and set CRS (couldn't find a way to infer the CRS)
+-- set CRS (couldn't find a way to infer the CRS)
 ALTER TABLE buildings ALTER COLUMN geom TYPE geometry (MultiPolygon, 3857);
 
--- delete small buildings
-DELETE FROM buildings WHERE ST_Area(geom) < 20;
+-- delete small buildings < 20qm
+-- TODO: figure out why "20" does not work as a value; I picked the 100 by checking what looked reasonable for http://localhost:7800/public.buildings.html#15.18/52.441297/13.557327
+DELETE FROM buildings WHERE ST_Area(geom) < 100;

--- a/app/process/buildings/buildings.sql
+++ b/app/process/buildings/buildings.sql
@@ -1,4 +1,7 @@
 DROP TABLE buildings;
+-- cluster all intersecting buildings
 SELECT (unnest(st_clusterintersecting(geom))) AS geom INTO buildings FROM _buildings_temp;
+-- join clusters and convert to multi polygons
 UPDATE buildings SET geom = st_multi(st_unaryunion(geom));
+-- copy results into final table and set CRS (couldn't find a way to infer the CRS)
 ALTER TABLE buildings ALTER COLUMN geom TYPE geometry (MultiPolygon, 3857);

--- a/app/process/buildings/buildings.sql
+++ b/app/process/buildings/buildings.sql
@@ -1,0 +1,4 @@
+DROP TABLE buildings;
+SELECT (unnest(st_clusterintersecting(geom))) AS geom INTO buildings FROM _buildings_temp;
+UPDATE buildings SET geom = st_multi(st_unaryunion(geom));
+ALTER TABLE buildings ALTER COLUMN geom TYPE geometry (MultiPolygon, 3857);

--- a/app/run-4-process.sh
+++ b/app/run-4-process.sh
@@ -51,6 +51,7 @@ ${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR
 
 echo "\e[1m\e[7m PROCESS – Topic: buildings \e[27m\e[21m"
 ${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}buildings/buildings.lua ${OSM_FILTERED_FILE}
+psql -q -f "${PROCESS_DIR}buildings/buildings.sql"
 
 echo "\e[1m\e[7m PROCESS – Topic: roadClassification \e[27m\e[21m"
 ${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}roadClassification/roadClassification.lua ${OSM_FILTERED_FILE}

--- a/app/run-4-process.sh
+++ b/app/run-4-process.sh
@@ -9,6 +9,16 @@ OSM_FILTERED_FILE=${OSM_DATADIR}openstreetmap-filtered.osm.pbf
 
 OSM_LOCAL_FILE=${OSM_DATADIR}openstreetmap-latest.osm.pbf
 
+run_lua() {
+  echo "\e[1m\e[7m PROCESS – Topic: $1 LUA \e[27m\e[21m"
+  ${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}$1.lua ${OSM_FILTERED_FILE}
+}
+
+run_psql() {
+  echo "\e[1m\e[7m PROCESS – Topic: $1 SQL \e[27m\e[21m"
+  psql -q -f "${PROCESS_DIR}$1.sql"
+}
+
 # LUA Docs https://osm2pgsql.org/doc/manual.html#running-osm2pgsql
 # One line/file per topic.
 # Order of topics is important b/c they might rely on their data
@@ -16,56 +26,29 @@ OSM_LOCAL_FILE=${OSM_DATADIR}openstreetmap-latest.osm.pbf
 echo "\e[1m\e[7m PROCESS – START \e[27m\e[21m"
 
 # lit and bikelanes should be at the top, so it's available ASAP
-echo "\e[1m\e[7m PROCESS – Topic: lit \e[27m\e[21m – Reminder: This table is available only after Postprocessing finished"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}lit/lit.lua ${OSM_FILTERED_FILE}
+echo "Reminder: The 'lit' table is available only after Postprocessing finished"
+run_lua "lit/lit"
 
-echo "\e[1m\e[7m PROCESS – Topic: bikelanes LUA \e[27m\e[21m – Reminder: This table is available only after Postprocessing finished"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}bikelanes/bikelanes.lua ${OSM_FILTERED_FILE}
+echo "Reminder: The 'bikelanes' table is available only after Postprocessing finished"
+run_lua "bikelanes/bikelanes"
+run_psql "bikelanes/bikelanes"
 
-echo "\e[1m\e[7m PROCESS – Topic: bikelanes SQL \e[27m\e[21m"
-psql -q -f "${PROCESS_DIR}bikelanes/bikelanes.sql"
+run_lua "boundaries"
+run_lua "places/places"
+run_lua "places/places_todoList"
+run_lua "education"
+run_lua "landuse"
+run_lua "publicTransport"
+run_lua "poiClassification/poiClassification"
+run_lua "poiClassification/poiClassification_todoList"
 
-echo "\e[1m\e[7m PROCESS – Topic: boundaries \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}boundaries.lua ${OSM_FILTERED_FILE}
+run_lua "buildings/buildings"
+run_psql "buildings/buildings"
 
-echo "\e[1m\e[7m PROCESS – Topic: places \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}places/places.lua ${OSM_FILTERED_FILE}
-
-echo "\e[1m\e[7m PROCESS – Topic: places_todoList \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}places/places_todoList.lua ${OSM_FILTERED_FILE}
-
-echo "\e[1m\e[7m PROCESS – Topic: education \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}education.lua ${OSM_FILTERED_FILE}
-
-echo "\e[1m\e[7m PROCESS – Topic: landuse \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}landuse.lua ${OSM_FILTERED_FILE}
-
-echo "\e[1m\e[7m PROCESS – Topic: publicTransport \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}publicTransport.lua ${OSM_FILTERED_FILE}
-
-echo "\e[1m\e[7m PROCESS – Topic: poiClassification \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}poiClassification/poiClassification.lua ${OSM_FILTERED_FILE}
-
-echo "\e[1m\e[7m PROCESS – Topic: poiClassification_todoList \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}poiClassification/poiClassification_todoList.lua ${OSM_FILTERED_FILE}
-
-echo "\e[1m\e[7m PROCESS – Topic: buildings \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}buildings/buildings.lua ${OSM_FILTERED_FILE}
-psql -q -f "${PROCESS_DIR}buildings/buildings.sql"
-
-echo "\e[1m\e[7m PROCESS – Topic: roadClassification \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}roadClassification/roadClassification.lua ${OSM_FILTERED_FILE}
-# psql -q -f "${PROCESS_DIR}roadClassification/roadClassification.sql"
-
-echo "\e[1m\e[7m PROCESS – Topic: maxspeed \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}maxspeed/maxspeed.lua ${OSM_FILTERED_FILE}
-# psql -q -f "${PROCESS_DIR}maxspeed/maxspeed.sql"
-
-echo "\e[1m\e[7m PROCESS – Topic: barriers \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}barriers/barriers.lua ${OSM_FILTERED_FILE}
-
-echo "\e[1m\e[7m PROCESS – Topic: surfaceQuality \e[27m\e[21m"
-${OSM2PGSQL_BIN} --create --output=flex --extra-attributes --style=${PROCESS_DIR}surfaceQuality/surfaceQuality.lua ${OSM_FILTERED_FILE}
+run_lua "roadClassification/roadClassification"
+run_lua "maxspeed/maxspeed"
+run_lua "barriers/barriers"
+run_lua "surfaceQuality/surfaceQuality"
 
 # ================================================
 # This should be the last step…

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "AGPL-3.0",
   "private": true,
   "scripts": {
+    "dev": "docker compose --profile osm_processing build && docker compose --profile osm_processing up",
     "release": "echo \"Use this format for the title: 'Release 2023-12-31'\" && gh pr create --base main --head develop --body \"\"",
     "test": "chmod +x ./run_tests.sh && ./run_tests.sh",
     "cleanup": "docker system prune --force && docker system prune --force --volumes"


### PR DESCRIPTION
This PR adds a geometric clustering on the buildings data set.
This reduce the size of the data and complexity of the data set as a whole because we don't need information of internal structure instead the inner and outer boundaries of buildings is what interests us.

This reduces the data set size to a bit less then the half even though most is gained through omitting the tags.
Example:
- all data ~ 180 mb
- without tags ~ 100 mb
- clustered ~ 80 mb

One down side is that through the intersection clustering we lose the tags and thus can't (for now) export this data set anymore.

Have a look the discussion in the related [Ticket](https://github.com/FixMyBerlin/private-issues/issues/582) for questions about this.

Maybe [this](http://www.danbaston.com/posts/2018/02/15/optimizing-postgis-geometries.html) could be helpful.

I also added a filter on the area size s.t. buildings under 20 sqm are removed.