### PR TITLE
Derive smoothness from `mtb:scale` and `tracktype`

### DIFF
--- a/app/process/roads_bikelanes/surfaceQuality/DeriveSmoothness.lua
+++ b/app/process/roads_bikelanes/surfaceQuality/DeriveSmoothness.lua
@@ -99,3 +99,31 @@ function SmoothnessFromSurface(surface)
   end
   return smoothness, source, confidence, todo
 end
+
+function SmoothnessFromMTBScale(scale)
+  if not scale then
+    return nil, nil, nil, "No MTB scale was given"
+  end
+  if Set({"0", "0+", "0-"})[scale] then
+    return "bad", "MTB scale to smoothness", "medium", nil
+  end 
+  return "very_bad", "MTB scale to smoothness", "medium", nil
+end
+
+function SmoothnessFromTrackType(type)
+  if not type then
+    return nil, nil, nil, "No track type was given"
+  end
+  local trackTypeToSmoothness = {
+    ["grade1"] = "good",
+    ["grade2"] = "intermediate",
+    ["grade3"] = "intermediate",
+    ["grade4"] = "bad",
+    ["grade5"] = "very_bad"
+  }
+  local smoothness = trackTypeToSmoothness[type]
+  if smoothness then
+    return smoothness, "track type to smoothness", "medium", nil
+  end
+  return nil, nil, nil, nil
+end

--- a/app/process/roads_bikelanes/surfaceQuality/DeriveSmoothness.lua
+++ b/app/process/roads_bikelanes/surfaceQuality/DeriveSmoothness.lua
@@ -100,6 +100,8 @@ function SmoothnessFromSurface(surface)
   return smoothness, source, confidence, todo
 end
 
+-- https://wiki.openstreetmap.org/wiki/Key:mtb:scale
+-- https://taginfo.openstreetmap.org/keys/mtb%3Ascale#values
 function SmoothnessFromMTBScale(scale)
   if not scale then
     return nil, nil, nil, "No MTB scale was given"
@@ -110,6 +112,10 @@ function SmoothnessFromMTBScale(scale)
   return "very_bad", "MTB scale to smoothness", "medium", nil
 end
 
+-- Wiki https://wiki.openstreetmap.org/wiki/Key:tracktype
+-- Categories that cyclosm.org use https://github.com/cyclosm/cyclosm-cartocss-style/wiki/Tag-to-Render
+-- Mapping of Smoothness<>Surface https://wiki.openstreetmap.org/wiki/Key:smoothness/Gallery
+-- Mapping of Smoothness<>Surface (Legacy) https://wiki.openstreetmap.org/wiki/Berlin/Verkehrswende/smoothness
 function SmoothnessFromTrackType(type)
   if not type then
     return nil, nil, nil, "No track type was given"
@@ -117,7 +123,7 @@ function SmoothnessFromTrackType(type)
   local trackTypeToSmoothness = {
     ["grade1"] = "good",
     ["grade2"] = "intermediate",
-    ["grade3"] = "intermediate",
+    ["grade3"] = "bad",
     ["grade4"] = "bad",
     ["grade5"] = "very_bad"
   }

--- a/app/process/roads_bikelanes/surfaceQuality/NormalizeSmoothness.lua
+++ b/app/process/roads_bikelanes/surfaceQuality/NormalizeSmoothness.lua
@@ -1,5 +1,5 @@
 require("Set")
-function SmoothnessDirect(smoothness)
+function NormalizeSmoothness(smoothness)
   if smoothness ~= nil then
     local smoothnessDirect = Set({
       "excellent",

--- a/app/process/roads_bikelanes/surfaceQuality/SurfaceQuality.lua
+++ b/app/process/roads_bikelanes/surfaceQuality/SurfaceQuality.lua
@@ -19,7 +19,9 @@ function SurfaceQuality(object)
 
   -- Try to find smoothess information in the following order:
   -- 1. `smoothess` tag
-  -- 2. `smoothess` extrapolated from surface data
+  -- 2. `smoothess` extrapolated from `surface` data
+  -- 3. `smoothess` extrapolated from `tracktype` tag, mostly on `highway=track`
+  -- 4. `smoothess` extrapolated from `mtb:scale` tag, mostly on `highway=path`
   local todo = nil
   local smoothness, smoothness_source, smoothness_confidence = NormalizeSmoothness(tags.smoothness)
   if smoothness == nil then

--- a/app/process/roads_bikelanes/surfaceQuality/SurfaceQuality.lua
+++ b/app/process/roads_bikelanes/surfaceQuality/SurfaceQuality.lua
@@ -3,8 +3,8 @@ package.path = package.path .. ";/app/process/shared/?.lua"
 package.path = package.path .. ";/app/process/roads_bikelanes/surfaceQuality/?.lua"
 require("IsFresh")
 require("SurfaceDirect")
-require("SmoothnessDirect")
-require("SmoothnessFromSurface")
+require("NormalizeSmoothness")
+require("DeriveSmoothness")
 require("Set")
 require("CopyTags")
 
@@ -21,9 +21,15 @@ function SurfaceQuality(object)
   -- 1. `smoothess` tag
   -- 2. `smoothess` extrapolated from surface data
   local todo = nil
-  local smoothness, smoothness_source, smoothness_confidence = SmoothnessDirect(tags.smoothness)
+  local smoothness, smoothness_source, smoothness_confidence = NormalizeSmoothness(tags.smoothness)
   if smoothness == nil then
     smoothness, smoothness_source, smoothness_confidence, todo = SmoothnessFromSurface(tags.surface)
+  end
+  if smoothness == nil then
+    smoothness, smoothness_source, smoothness_confidence, todo = SmoothnessFromTrackType(tags.tracktype)
+  end
+  if smoothness == nil then
+    smoothness, smoothness_source, smoothness_confidence, todo = SmoothnessFromMTBScale(tags["mtb:scale"])
   end
 
   -- all tags that are shown on the application

--- a/app/process/shared/ExcludeHighways.lua
+++ b/app/process/shared/ExcludeHighways.lua
@@ -29,13 +29,6 @@ function ExcludeHighways(tags)
     return true, "Excluded by `informal=yes`"
   end
 
-  if tags['mtb:scale'] then
-    return true, "Excluded since `mtb:scale` indicates a special interest path"
-  end
-
-  if tags.tracktype == "grade5" then
-    return true, "Excluded since `tracktype=grade5` indicates a special interest path"
-  end
 
   -- Skip all unwanted `highway=service + service=<value>` values
   -- The key can have random values, we mainly want to skip


### PR DESCRIPTION
This PR implements a mapping from the tags 'mtb:scale` and `tracktype` to derive values for smoothness.
Closes [973](https://github.com/FixMyBerlin/private-issues/issues/973).
The mapping is based on [Wiki tracktype ](https://wiki.openstreetmap.org/wiki/Key:tracktype) and [Wiki mtb:scale](https://wiki.openstreetmap.org/wiki/Key:mtb:scale#mtb:scale=0-6)