### PR TITLE
Add Bicycle Parking Data Set

### DIFF
--- a/app/process/bicycleParking/bicycleParking.lua
+++ b/app/process/bicycleParking/bicycleParking.lua
@@ -28,7 +28,7 @@ function ExitProcessing(object)
   end
 end
 
-function capacityNormalization(tags)
+local function capacityNormalization(tags)
   local capacities = { capacity = tonumber(tags.capacity) }
   if capacities.capacity == nil then return capacities end
   for key, val in pairs(tags) do

--- a/app/process/bicycleParking/bicycleParking.lua
+++ b/app/process/bicycleParking/bicycleParking.lua
@@ -80,6 +80,7 @@ function osm2pgsql.process_way(object)
   local tags = processTags(object.tags)
   local meta = Metadata(object)
 
+  -- convert bicycle parking mapped as lines or areas to points by taking the centroid
   nodeTable:insert({
     tags = tags,
     meta = meta,

--- a/app/process/bicycleParking/bicycleParking.lua
+++ b/app/process/bicycleParking/bicycleParking.lua
@@ -57,7 +57,7 @@ local function processTags(tags)
   local processedTags = capacityNormalization(tags)
   CopyTags(processedTags, tags, tags_cc, "osm_")
 
-  local checkDateTag = "check_date:amenity"
+  local checkDateTag = "check_date"
   if tags[checkDateTag] then
     processedTags.age = AgeInDays(ParseDate(tags[checkDateTag]))
   end

--- a/app/process/bicycleParking/bicycleParking.lua
+++ b/app/process/bicycleParking/bicycleParking.lua
@@ -66,4 +66,9 @@ function osm2pgsql.process_way(object)
     meta = Metadata(object),
     geom = object:as_polygon(),
   })
+  nodeTable:insert({
+    tags = capacityNormalization(tags),
+    meta = Metadata(object),
+    geom = object:as_polygon():centroid(),
+  })
 end

--- a/app/process/bicycleParking/bicycleParking.lua
+++ b/app/process/bicycleParking/bicycleParking.lua
@@ -48,7 +48,8 @@ function capacityNormalization(tags)
 end
 
 -- this is the list of tags found in the wiki: https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dbicycle_parking
-local tags_cc = {"area", "operator", "covered", "indoor", "foot_traffi", "access", "capacity", "fee","bicycle_parking","cyclestreets_id", "maxstay", "surveillance"}
+-- also https://wiki.openstreetmap.org/wiki/Berlin/Verkehrswende/Fahrradparkpl%C3%A4tze
+local tags_cc = {"area", "operator", "operator:type", "covered", "indoor", "access", "cargo_bike", "capacity", "capacity:cargo_bike", "fee", "lit", "surface", "bicycle_parking", "mapillary", "maxstay", "surveillance", "bicycle_parking:count", "bicycle_parking:position", "traffic_sign" }
 
 function osm2pgsql.process_node(object)
   if ExitProcessing(object) then return end

--- a/app/process/bicycleParking/bicycleParking.lua
+++ b/app/process/bicycleParking/bicycleParking.lua
@@ -4,7 +4,7 @@ require("Metadata")
 
 local nodeTable = osm2pgsql.define_table({
   name = 'bicycleParking-points',
-  ids = { type = 'node', id_column = 'osm_id', type_column = 'osm_type' },
+  ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
     { column = 'tags', type = 'jsonb' },
     { column = 'meta', type = 'jsonb' },
@@ -14,24 +14,44 @@ local nodeTable = osm2pgsql.define_table({
 
 local areaTable = osm2pgsql.define_table({
   name = 'bicycleParking-areas',
-  ids = { type = 'node', id_column = 'osm_id', type_column = 'osm_type' },
+  ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
     { column = 'tags', type = 'jsonb' },
     { column = 'meta', type = 'jsonb' },
-    { column = 'geom', type = 'linestring' },
+    { column = 'geom', type = 'polygon' },
   }
 })
+
 function ExitProcessing(object) 
   if object.tags.amenity ~= 'bicycle_parking' then
     return true
   end
 end
 
+function capacityNormalization(tags)
+  local capacities = {capacity = tonumber(tags.capacity) or 0}
+  for key, val in pairs(tags) do
+    if osm2pgsql.has_prefix(key, "capacity") then
+      val = tonumber(val)
+      if val ~= nil then
+        capacities.capacity = capacities.capacity - val
+      end
+      capacities[key] = val
+    end
+  end
+  for k, v in pairs(capacities) do
+    if v == 0 then
+      capacities[k] = nil
+    end
+  end
+  return capacities
+end
+
 function osm2pgsql.process_node(object)
   local tags = object.tags
   if ExitProcessing(object) then return end
   nodeTable:insert({
-    tags = tags,
+    tags = capacityNormalization(tags),
     meta = Metadata(object),
     geom = object:as_point()
   })
@@ -40,8 +60,9 @@ end
 function osm2pgsql.process_way(object)
   if ExitProcessing(object) or not object.is_closed then return end
 
+  local tags = object.tags
   areaTable:insert({
-    tags = object.tags,
+    tags = capacityNormalization(tags),
     meta = Metadata(object),
     geom = object:as_polygon(),
   })

--- a/app/process/bicycleParking/bicycleParking.lua
+++ b/app/process/bicycleParking/bicycleParking.lua
@@ -22,14 +22,15 @@ local areaTable = osm2pgsql.define_table({
   }
 })
 
-function ExitProcessing(object) 
+function ExitProcessing(object)
   if object.tags.amenity ~= 'bicycle_parking' then
     return true
   end
 end
 
 function capacityNormalization(tags)
-  local capacities = {capacity = tonumber(tags.capacity) or 0}
+  local capacities = { capacity = tonumber(tags.capacity)}
+  if capacities.capacity == nil then return capacities end
   for key, val in pairs(tags) do
     if osm2pgsql.has_prefix(key, "capacity") then
       val = tonumber(val)
@@ -49,7 +50,9 @@ end
 
 -- this is the list of tags found in the wiki: https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dbicycle_parking
 -- also https://wiki.openstreetmap.org/wiki/Berlin/Verkehrswende/Fahrradparkpl%C3%A4tze
-local tags_cc = {"area", "operator", "operator:type", "covered", "indoor", "access", "cargo_bike", "capacity", "capacity:cargo_bike", "fee", "lit", "surface", "bicycle_parking", "mapillary", "maxstay", "surveillance", "bicycle_parking:count", "bicycle_parking:position", "traffic_sign" }
+local tags_cc = { "area", "operator", "operator:type", "covered", "indoor", "access", "cargo_bike", "capacity",
+  "capacity:cargo_bike", "fee", "lit", "surface", "bicycle_parking", "mapillary", "maxstay", "surveillance",
+  "bicycle_parking:count", "bicycle_parking:position", "traffic_sign" }
 
 function osm2pgsql.process_node(object)
   if ExitProcessing(object) then return end
@@ -68,8 +71,8 @@ function osm2pgsql.process_way(object)
   local tags = capacityNormalization(object.tags)
   CopyTags(object.tags, tags, tags_cc, "osm_")
 
-  local meta =  Metadata(object)
-  
+  local meta = Metadata(object)
+
   nodeTable:insert({
     tags = tags,
     meta = meta,

--- a/app/process/bicycleParking/bicycleParking.lua
+++ b/app/process/bicycleParking/bicycleParking.lua
@@ -55,26 +55,29 @@ function osm2pgsql.process_node(object)
   local tags = capacityNormalization(object.tags)
   CopyTags(object.tags, tags, tags_cc, "osm_")
   nodeTable:insert({
-    tags = capacityNormalization(tags),
+    tags = tags,
     meta = Metadata(object),
     geom = object:as_point()
   })
 end
 
 function osm2pgsql.process_way(object)
-  if ExitProcessing(object) or not object.is_closed then return end
+  if ExitProcessing(object) then return end
 
   local tags = capacityNormalization(object.tags)
   CopyTags(object.tags, tags, tags_cc, "osm_")
+
+  local meta =  Metadata(object)
   
-  areaTable:insert({
-    tags = tags,
-    meta = Metadata(object),
-    geom = object:as_polygon(),
-  })
   nodeTable:insert({
     tags = tags,
-    meta = Metadata(object),
+    meta = meta,
     geom = object:as_polygon():centroid(),
+  })
+  if not object.is_closed then return end
+  areaTable:insert({
+    tags = tags,
+    meta = meta,
+    geom = object:as_polygon(),
   })
 end

--- a/app/process/bicycleParking/bicycleParking.lua
+++ b/app/process/bicycleParking/bicycleParking.lua
@@ -1,0 +1,48 @@
+package.path = package.path .. ";/app/process/helper/?.lua;/app/process/shared/?.lua"
+require("Set")
+require("Metadata")
+
+local nodeTable = osm2pgsql.define_table({
+  name = 'bicycleParking-points',
+  ids = { type = 'node', id_column = 'osm_id', type_column = 'osm_type' },
+  columns = {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'meta', type = 'jsonb' },
+    { column = 'geom', type = 'point' },
+  }
+})
+
+local areaTable = osm2pgsql.define_table({
+  name = 'bicycleParking-areas',
+  ids = { type = 'node', id_column = 'osm_id', type_column = 'osm_type' },
+  columns = {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'meta', type = 'jsonb' },
+    { column = 'geom', type = 'linestring' },
+  }
+})
+function ExitProcessing(object) 
+  if object.tags.amenity ~= 'bicycle_parking' then
+    return true
+  end
+end
+
+function osm2pgsql.process_node(object)
+  local tags = object.tags
+  if ExitProcessing(object) then return end
+  nodeTable:insert({
+    tags = tags,
+    meta = Metadata(object),
+    geom = object:as_point()
+  })
+end
+
+function osm2pgsql.process_way(object)
+  if ExitProcessing(object) or not object.is_closed then return end
+
+  areaTable:insert({
+    tags = object.tags,
+    meta = Metadata(object),
+    geom = object:as_polygon(),
+  })
+end

--- a/app/run-4-process.sh
+++ b/app/run-4-process.sh
@@ -12,6 +12,8 @@ echo "Reminder: The 'bikelanes' table is available only after Postprocessing fin
 run_lua "roads_bikelanes/roads_bikelanes"
 run_psql "roads_bikelanes/bikelanes/bikelanes"
 
+run_lua "bicycleParking/bicycleParking"
+
 run_lua "legacy_bikelanes/bikelanesPresence"
 run_lua "legacy_surfaceQuality/surfaceQuality"
 run_lua "legacy_roadClassification/roadClassification"


### PR DESCRIPTION
This PR adds two data sets containing entries of bicycle parking infrastructure. One contains point geometries of bicycle parking and the other contains mostly parking areas which are mapped as areas. The point data set also includes the entries of the second data set where the respective point corresponds to the centroid of the mapped area.

Capacity values get processed s.t. the `capacity` tag only contains the number of "normal" bicycle parking spots and not the total parking spots e.g. `capacity = capacity - capacity:cargo_bikes`. Apart from that we copy only the tags described on the [OSM Wiki - Bicycle Parking](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dbicycle_parking) page.

[Related Ticket](https://github.com/FixMyBerlin/private-issues/issues/1094)