### PR TITLE
Base oneway logic on categorization

### DIFF
--- a/app/process/roads_bikelanes/bikelanes/Bikelanes.lua
+++ b/app/process/roads_bikelanes/bikelanes/Bikelanes.lua
@@ -12,6 +12,7 @@ require("ToMarkdownList")
 require("DeriveSurface")
 require("DeriveSmoothness")
 require("BikelanesTodos")
+require("InferOneway")
 
 
 -- these tags are copied (Eigennamen)
@@ -33,10 +34,6 @@ local tags_cc = {
   "mapillary",
   "description",
 }
-
-local onewayAssumedNo = Set({ 'bicycleRoad', 'pedestrianAreaBicycleYes' })
-local onewayImplicitYes = Set({ 'cyclewayOnHighway_exclusive', 'cyclewayOnHighway_advisory',
-  'cyclewayOnHighway_advisoryOrExclusive', 'sharedMotorVehicleLane' , 'cyclewayOnHighwayBetweenLanes', 'sharedBusLane'})
 
 function Bikelanes(object)
   local tags = object.tags
@@ -69,16 +66,10 @@ function Bikelanes(object)
       if category ~= nil then
         local results = { _infrastructureExists = true, category = category, offset = sign * RoadWidth(tags) / 2 }
 
+        results.oneway = cycleway.oneway
         -- Our atlas-app inspector should be explicit about tagging that OSM considers default/implicit
-        if cycleway.oneway == nil then
-          if onewayAssumedNo[category] then
-            results.oneway = 'assumed_no'
-          end
-          if onewayImplicitYes[category] then
-            results.oneway = 'implicit_yes'
-          end
-        else
-          results.oneway = cycleway.oneway
+        if results.oneway == nil then
+          results.oneway = InferOneway(category)
         end
 
         -- === Processing on the transformed dataset ===

--- a/app/process/roads_bikelanes/bikelanes/Bikelanes.lua
+++ b/app/process/roads_bikelanes/bikelanes/Bikelanes.lua
@@ -66,11 +66,8 @@ function Bikelanes(object)
       if category ~= nil then
         local results = { _infrastructureExists = true, category = category, offset = sign * RoadWidth(tags) / 2 }
 
-        results.oneway = cycleway.oneway
-        -- Our atlas-app inspector should be explicit about tagging that OSM considers default/implicit
-        if results.oneway == nil then
-          results.oneway = InferOneway(category)
-        end
+        -- Our data should be explicit about tagging that OSM considers default/implicit as well assumed defaults.
+        results.oneway = Sanitize(cycleway.oneway, Set({'yes', 'no'})) or InferOneway(category)
 
         -- === Processing on the transformed dataset ===
         local freshTag = "check_date"

--- a/app/process/roads_bikelanes/bikelanes/Bikelanes.lua
+++ b/app/process/roads_bikelanes/bikelanes/Bikelanes.lua
@@ -34,6 +34,10 @@ local tags_cc = {
   "description",
 }
 
+local onewayAssumedNo = Set({ 'bicycleRoad', 'pedestrianAreaBicycleYes' })
+local onewayImplicitYes = Set({ 'cyclewayOnHighway_exclusive', 'cyclewayOnHighway_advisory',
+  'cyclewayOnHighway_advisoryOrExclusive', 'sharedMotorVehicleLane' , 'cyclewayOnHighwayBetweenLanes', 'sharedBusLane'})
+
 function Bikelanes(object)
   local tags = object.tags
 
@@ -67,9 +71,10 @@ function Bikelanes(object)
 
         -- Our atlas-app inspector should be explicit about tagging that OSM considers default/implicit
         if cycleway.oneway == nil then
-          if tags.bicycle_road == 'yes' then
-            results.oneway = 'implicit_no'
-          else
+          if onewayAssumedNo[category] then
+            results.oneway = 'assumed_no'
+          end
+          if onewayImplicitYes[category] then
             results.oneway = 'implicit_yes'
           end
         end

--- a/app/process/roads_bikelanes/bikelanes/Bikelanes.lua
+++ b/app/process/roads_bikelanes/bikelanes/Bikelanes.lua
@@ -77,6 +77,8 @@ function Bikelanes(object)
           if onewayImplicitYes[category] then
             results.oneway = 'implicit_yes'
           end
+        else
+          results.oneway = cycleway.oneway
         end
 
         -- === Processing on the transformed dataset ===

--- a/app/process/roads_bikelanes/bikelanes/InferOneway.lua
+++ b/app/process/roads_bikelanes/bikelanes/InferOneway.lua
@@ -1,0 +1,12 @@
+local onewayAssumedNo = Set({ 'bicycleRoad', 'pedestrianAreaBicycleYes' })
+local onewayImplicitYes = Set({ 'cyclewayOnHighway_exclusive', 'cyclewayOnHighway_advisory',
+  'cyclewayOnHighway_advisoryOrExclusive', 'sharedMotorVehicleLane' , 'cyclewayOnHighwayBetweenLanes', 'sharedBusLane'})
+
+function InferOneway(category)
+  if onewayAssumedNo[cycleway.category] then
+    return 'assumed_no'
+  end
+  if onewayImplicitYes[category] then
+    return 'implicit_yes'
+  end
+end

--- a/app/process/roads_bikelanes/bikelanes/InferOneway.lua
+++ b/app/process/roads_bikelanes/bikelanes/InferOneway.lua
@@ -1,6 +1,32 @@
-local onewayAssumedNo = Set({ 'bicycleRoad', 'pedestrianAreaBicycleYes' })
-local onewayImplicitYes = Set({ 'cyclewayOnHighway_exclusive', 'cyclewayOnHighway_advisory',
-  'cyclewayOnHighway_advisoryOrExclusive', 'sharedMotorVehicleLane' , 'cyclewayOnHighwayBetweenLanes', 'sharedBusLane'})
+local onewayAssumedNo = Set({ 
+  'bicycleRoad', -- road shared, both lanes
+  'livingStreet', -- road shared, both lanes
+  'pedestrianAreaBicycleYes', -- road shared, both lanes
+  'sharedMotorVehicleLane', -- (both) road shared, both lanes, (left|right would be `implicit_yes`)
+  'explicitSharedLaneButNoSignage', -- (both) road shared, both lanes, (left|right would be `implicit_yes`)
+  'footAndCyclewayShared_isolated', -- "track"-like
+  'footAndCyclewaySegregated_isolated', -- "track"-like
+  'cycleway_adjoining', -- "track"-like and `oneway=yes` (common in cities) is usually explicit
+  'cycleway_isolated', -- road for bikes `oneway=yes` unexpected or usually explicit
+  'cycleway_adjoiningOrIsolated', -- "track"-like
+  'crossing', -- really unknown, but `oneway=yes` (which is common in cities) is usually explicit
+  'cyclewayLink', -- really unknown, but `oneway=yes` (which is common in cities) is usually explicit
+  'needsClarification' -- really unknown, but `oneway=yes` (which is common in cities) is usually explicit
+})
+local onewayImplicitYes = Set({ 
+  'cyclewayOnHighway_advisory', -- "lane"-like
+  'cyclewayOnHighway_exclusive', -- "lane"-like
+  'cyclewayOnHighway_advisoryOrExclusive', -- "lane"-like
+  'cyclewayOnHighwayBetweenLanes', -- "lane"-like
+  'sharedBusLane', -- "shared lane"-like
+  'footAndCyclewayShared_adjoining', -- "shared lane"-like
+  'footAndCyclewayShared_adjoiningOrIsolated' -- unclear, fall back to "shared lane"-like
+  'footAndCyclewaySegregated_adjoining', -- "lane"-like
+  'footAndCyclewaySegregated_adjoiningOrIsolated' -- unclear, fall back to "lane"-like
+  'footwayBicycleYes_adjoining', -- "shared lane"-like
+  'footwayBicycleYes_isolated', -- "shared lane"-like, still assuming "oneway=yes" because too little space or it would be "footAndCyclewayShared_isolated"
+  'footwayBicycleYes_adjoiningOrIsolated' -- unclear, fall back to "shared lane"-like
+})
 
 function InferOneway(category)
   if onewayAssumedNo[category] then

--- a/app/process/roads_bikelanes/bikelanes/InferOneway.lua
+++ b/app/process/roads_bikelanes/bikelanes/InferOneway.lua
@@ -27,7 +27,10 @@ local onewayImplicitYes = Set({
   'footwayBicycleYes_isolated', -- "shared lane"-like, still assuming "oneway=yes" because too little space or it would be "footAndCyclewayShared_isolated"
   'footwayBicycleYes_adjoiningOrIsolated' -- unclear, fall back to "shared lane"-like
 })
-
+---comment
+---@param category string
+---@return 'assumed_no' | 'implicit_yes' | 'unknown'
+--- Infer oneway information based on the given category
 function InferOneway(category)
   if onewayAssumedNo[category] then
     return 'assumed_no'
@@ -35,4 +38,5 @@ function InferOneway(category)
   if onewayImplicitYes[category] then
     return 'implicit_yes'
   end
+  return 'unknown'
 end

--- a/app/process/roads_bikelanes/bikelanes/InferOneway.lua
+++ b/app/process/roads_bikelanes/bikelanes/InferOneway.lua
@@ -1,4 +1,4 @@
-local onewayAssumedNo = Set({ 
+local onewayAssumedNo = Set({
   'bicycleRoad', -- road shared, both lanes
   'livingStreet', -- road shared, both lanes
   'pedestrianAreaBicycleYes', -- road shared, both lanes
@@ -13,16 +13,16 @@ local onewayAssumedNo = Set({
   'cyclewayLink', -- really unknown, but `oneway=yes` (which is common in cities) is usually explicit
   'needsClarification' -- really unknown, but `oneway=yes` (which is common in cities) is usually explicit
 })
-local onewayImplicitYes = Set({ 
+local onewayImplicitYes = Set({
   'cyclewayOnHighway_advisory', -- "lane"-like
   'cyclewayOnHighway_exclusive', -- "lane"-like
   'cyclewayOnHighway_advisoryOrExclusive', -- "lane"-like
   'cyclewayOnHighwayBetweenLanes', -- "lane"-like
   'sharedBusLane', -- "shared lane"-like
   'footAndCyclewayShared_adjoining', -- "shared lane"-like
-  'footAndCyclewayShared_adjoiningOrIsolated' -- unclear, fall back to "shared lane"-like
+  'footAndCyclewayShared_adjoiningOrIsolated', -- unclear, fall back to "shared lane"-like
   'footAndCyclewaySegregated_adjoining', -- "lane"-like
-  'footAndCyclewaySegregated_adjoiningOrIsolated' -- unclear, fall back to "lane"-like
+  'footAndCyclewaySegregated_adjoiningOrIsolated', -- unclear, fall back to "lane"-like
   'footwayBicycleYes_adjoining', -- "shared lane"-like
   'footwayBicycleYes_isolated', -- "shared lane"-like, still assuming "oneway=yes" because too little space or it would be "footAndCyclewayShared_isolated"
   'footwayBicycleYes_adjoiningOrIsolated' -- unclear, fall back to "shared lane"-like

--- a/app/process/roads_bikelanes/bikelanes/InferOneway.lua
+++ b/app/process/roads_bikelanes/bikelanes/InferOneway.lua
@@ -27,16 +27,22 @@ local onewayImplicitYes = Set({
   'footwayBicycleYes_isolated', -- "shared lane"-like, still assuming "oneway=yes" because too little space or it would be "footAndCyclewayShared_isolated"
   'footwayBicycleYes_adjoiningOrIsolated' -- unclear, fall back to "shared lane"-like
 })
----comment
+
 ---@param category string
 ---@return 'assumed_no' | 'implicit_yes' | 'unknown'
 --- Infer oneway information based on the given category
 function InferOneway(category)
+-- TODO:
+-- We want to make sure that "Fahrradstraßen" which allow bidirectional bicycle traffic
+-- but only unidirectional motor_vehicle traffic can express this fact in our atlas Inspector.
+-- Which is why we invent a new value `car_not_bike` for the `oneway` tag.
+
   if onewayAssumedNo[category] then
     return 'assumed_no'
   end
   if onewayImplicitYes[category] then
     return 'implicit_yes'
   end
+  -- This should never happen / maybe in some kind of TODO-list
   return 'unknown'
 end

--- a/app/process/roads_bikelanes/bikelanes/InferOneway.lua
+++ b/app/process/roads_bikelanes/bikelanes/InferOneway.lua
@@ -3,7 +3,7 @@ local onewayImplicitYes = Set({ 'cyclewayOnHighway_exclusive', 'cyclewayOnHighwa
   'cyclewayOnHighway_advisoryOrExclusive', 'sharedMotorVehicleLane' , 'cyclewayOnHighwayBetweenLanes', 'sharedBusLane'})
 
 function InferOneway(category)
-  if onewayAssumedNo[cycleway.category] then
+  if onewayAssumedNo[category] then
     return 'assumed_no'
   end
   if onewayImplicitYes[category] then

--- a/app/process/roads_bikelanes/bikelanes/categories.lua
+++ b/app/process/roads_bikelanes/bikelanes/categories.lua
@@ -63,13 +63,6 @@ end
 local function bicycleRoad(tags)
   if tags.bicycle_road == "yes"
       or osm2pgsql.has_prefix(tags.traffic_sign, 'DE:244') then
-    -- We want to make sure that "Fahrradstraßen" which allow bidirectional bicycle traffic
-    -- but only unidirectional motor_vehicle traffic can express this fact in our atlas Inspector.
-    -- Which is why we invent a new value `car_not_bike` for the `oneway` tag.
-    if tags.oneway == 'yes' and tags['oneway:bicycle'] == 'no' then
-      tags.oneway = 'car_not_bike'
-    end
-
     -- Subcategory when bicycle road allows vehicle traffic
     if tags.traffic_sign == 'DE:244.1,1020-30'
         or tags.traffic_sign == 'DE:244,1020-30'

--- a/app/process/roads_bikelanes/bikelanes/transformations.lua
+++ b/app/process/roads_bikelanes/bikelanes/transformations.lua
@@ -41,9 +41,9 @@ local sideDirectionMap = {
 -- these tags get transformed from the forward backward schema
 local directedTags = { 'cycleway:lanes', 'bicycle:lanes' }
 function GetTransformedObjects(tags, transformations)
-  local center = {}
-  for k, v in pairs(tags) do center[k] = v end
+  local center =  MergeTable({}, tags)
   center.sign = CENTER_SIGN -- Overwrite any OSM tag 'sign'
+  center.oneway = tags['oneway:bicycle'] or tags.oneway -- give `bicycle:oneway` precedence
 
   local results = { center }
   -- don't transform paths


### PR DESCRIPTION
This PR reworks how we assume oneways when the information is not explicitly given. For `center` objects it also inferences `oneway` in a different way s.t. `oneway:bicycle` > `oneway`.