### PR TITLE
Improve "Bus+Fahrrad frei" and add "Radweg+Bus frei" ✅ 

### DIFF
--- a/processing/topics/roads_bikelanes/bikelanes/categories.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/categories.lua
@@ -234,11 +234,23 @@ local function cyclewayOnHighwayBetweenLanes(tags)
   end
 end
 
+-- Bussonderfahrstreifen mit Fahrrad Frei
+-- Wiki https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway%3Dshare_busway
+-- "Fahrrad frei" traffic_sign=DE:245,1022-10
+--   - https://trafficsigns.osm-verkehrswende.org/?signs=DE%3A245%7CDE%3A1022-10
+-- "Fahrrad frei, Taxi frei" traffic_sign=DE:245,1022-10,1026-30
+--   - https://trafficsigns.osm-verkehrswende.org/?signs=DE%3A245%7CDE%3A1022-10%7CDE%3A1026-30
+-- "Fahrrad & Mofa frei" traffic_sign=DE:245,1022-14
+-- (History: Until 2023-03-2: cyclewayAlone)
 local function sharedBusLane(tags)
-  if tags.highway == "cycleway" then
-    if tags.cycleway == "share_busway" or tags.cycleway == "opposite_share_busway" then
-      return "sharedBusLane" -- (until 2023-03-2: cyclewayAlone)
-    end
+  local taggedWithAccessTagging = tags.highway == "cycleway" and
+      (tags.cycleway == "share_busway" or tags.cycleway == "opposite_share_busway")
+  local taggedWithTrafficsign = osm2pgsql.has_prefix(tags.traffic_sign, "DE:245") and
+      (IsTermInString("1022-10", tags.traffic_sign) or IsTermInString("1022-14", tags.traffic_sign))
+  if taggedWithAccessTagging or taggedWithTrafficsign then
+    return "sharedBusLane"
+  end
+end
   end
 end
 

--- a/processing/topics/roads_bikelanes/bikelanes/categories.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/categories.lua
@@ -242,15 +242,30 @@ end
 --   - https://trafficsigns.osm-verkehrswende.org/?signs=DE%3A245%7CDE%3A1022-10%7CDE%3A1026-30
 -- "Fahrrad & Mofa frei" traffic_sign=DE:245,1022-14
 -- (History: Until 2023-03-2: cyclewayAlone)
-local function sharedBusLane(tags)
+local function sharedBusLaneBusWithBike(tags)
   local taggedWithAccessTagging = tags.highway == "cycleway" and
       (tags.cycleway == "share_busway" or tags.cycleway == "opposite_share_busway")
   local taggedWithTrafficsign = osm2pgsql.has_prefix(tags.traffic_sign, "DE:245") and
       (IsTermInString("1022-10", tags.traffic_sign) or IsTermInString("1022-14", tags.traffic_sign))
   if taggedWithAccessTagging or taggedWithTrafficsign then
-    return "sharedBusLane"
+    return "sharedBusLane" -- NOTE: rename to "sharedBusLaneBusWithBike"
   end
 end
+
+-- Radfahrstreifen mit Freigabe Busverkehr
+-- Traffic sign traffic_sign=DE:237,1024-14
+--   - https://trafficsigns.osm-verkehrswende.org/?signs=DE%3A237%7CDE%3A1024-14
+-- OSM Verkehrswende Recommended Tagging is too complex for now, we mainly look at the traffic_sign
+-- and the few uses of `cycleway:right:lane=share_busway`.
+--   - 81 in DE https://taginfo.geofabrik.de/europe:germany/tags/cycleway%3Aright%3Alane=share_busway#overview
+--   - 87 overall https://taginfo.openstreetmap.org/tags/cycleway%3Aright%3Alane=share_busway#overview
+--   - 1 overall for left https://taginfo.openstreetmap.org/tags/cycleway%3Aleft%3Alane=share_busway#overview
+local function sharedBusLaneBikeWithBus(tags)
+  local taggedWithAccessTagging = tags.highway == "cycleway" and tags.lane == "share_busway"
+  local taggedWithTrafficsign =
+      osm2pgsql.has_prefix(tags.traffic_sign, "DE:237") and IsTermInString("1024-14", tags.traffic_sign)
+  if taggedWithAccessTagging or taggedWithTrafficsign then
+    return "sharedBusLaneBikeWithBus"
   end
 end
 
@@ -301,7 +316,8 @@ function CategorizeBikelane(tags)
     crossing,
     livingStreet,
     bicycleRoad,
-    sharedBusLane,
+    sharedBusLaneBikeWithBus,
+    sharedBusLaneBusWithBike,
     sharedLane,
     pedestrianAreaBicycleYes,
     sharedMotorVehicleLane,


### PR DESCRIPTION
The Radweg+Bus frei tagging is not well standardized in OSM so we look at the traffic signs mainly.

See https://github.com/FixMyBerlin/private-issues/issues/1305.