### PR TITLE
Generalization for Roads 

### DIFF
--- a/app/POSTPROCESS.sql
+++ b/app/POSTPROCESS.sql
@@ -2,25 +2,3 @@ BEGIN;
 DROP TABLE IF EXISTS bikelanes CASCADE;
 ALTER TABLE _bikelanes_temp RENAME TO bikelanes;
 COMMIT;
-
-CREATE OR REPLACE
-    FUNCTION public.roads_generalized(z integer, x integer, y integer)
-    RETURNS bytea AS $$
-DECLARE
-  mvt bytea;
-BEGIN
-  SELECT INTO mvt ST_AsMVT(tile, 'roads_generalized', 4096, 'g') FROM (
-    select
-    *,
-      ST_AsMVTGeom(
-          geom,
-          ST_TileEnvelope(z, x, y),
-          4096, 64, true) AS g
-    FROM roads
-    WHERE (geom && ST_TileEnvelope(z, x, y)) and (not tags?'_minZoom' or z >= (tags->'_minZoom')::integer )
-  ) as tile WHERE geom IS NOT NULL;
-  RETURN mvt;
-END
-$$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
-
-select * from roads where not tags?'_minZoom';

--- a/app/POSTPROCESS.sql
+++ b/app/POSTPROCESS.sql
@@ -2,3 +2,23 @@ BEGIN;
 DROP TABLE IF EXISTS bikelanes CASCADE;
 ALTER TABLE _bikelanes_temp RENAME TO bikelanes;
 COMMIT;
+
+CREATE OR REPLACE
+    FUNCTION public.roads_generalized(z integer, x integer, y integer)
+    RETURNS bytea AS $$
+DECLARE
+  mvt bytea;
+BEGIN
+  SELECT INTO mvt ST_AsMVT(tile, 'function_zxy_query', 4096, 'geom') FROM (
+    SELECT
+      ST_AsMVTGeom(
+          geom,
+          ST_TileEnvelope(z, x, y),
+          4096, 64, true) AS geom
+    FROM roads
+    WHERE (geom && ST_TileEnvelope(z, x, y)) and (not tags?'_minZoom' or z >= (tags->'_minZoom')::integer )
+  ) as tile WHERE geom IS NOT NULL;
+
+  RETURN mvt;
+END
+$$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;

--- a/app/POSTPROCESS.sql
+++ b/app/POSTPROCESS.sql
@@ -9,16 +9,18 @@ CREATE OR REPLACE
 DECLARE
   mvt bytea;
 BEGIN
-  SELECT INTO mvt ST_AsMVT(tile, 'function_zxy_query', 4096, 'geom') FROM (
-    SELECT
+  SELECT INTO mvt ST_AsMVT(tile, 'roads_generalized', 4096, 'g') FROM (
+    select
+    *,
       ST_AsMVTGeom(
           geom,
           ST_TileEnvelope(z, x, y),
-          4096, 64, true) AS geom
+          4096, 64, true) AS g
     FROM roads
     WHERE (geom && ST_TileEnvelope(z, x, y)) and (not tags?'_minZoom' or z >= (tags->'_minZoom')::integer )
   ) as tile WHERE geom IS NOT NULL;
-
   RETURN mvt;
 END
 $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+
+select * from roads where not tags?'_minZoom';

--- a/app/process/roads_bikelanes/roadClassification/RoadClassification.lua
+++ b/app/process/roads_bikelanes/roadClassification/RoadClassification.lua
@@ -13,6 +13,16 @@ local tags_prefixed = {
   'traffic_sign:backward',
 }
 
+local minZoom11 = Set({ 'residential',
+  'living_street',
+  'bicycle_road',
+  'pedestrian',
+  'unclassified',
+  'residential_priority_road',
+  'unspecified_road',
+  'service_road',
+  'service_alley' })
+
 function RoadClassification(object)
   local tags = object.tags
   local result_tags = {}
@@ -95,6 +105,10 @@ function RoadClassification(object)
   end
   if tags['oneway:bicycle'] == 'no' or tags['oneway:bicycle'] then
     result_tags['road_oneway:bicycle'] = tags['oneway:bicycle']
+  end
+
+  if minZoom11[result_tags.road] then
+    result_tags._minZoom = 11
   end
 
   CopyTags(result_tags, tags, tags_copied)


### PR DESCRIPTION
This PR demonstrates one possible solution to generalize our roads data. The method can be applied to any data.

How it works:
1. In Lua we set a `tags->_minZoom=x` to our desired Zoom boundary `x`
2. Afterwards we use an [function layer](https://maplibre.org/martin/sources-pg-functions.html) which filters the displayed geometries s.t. geometries are only displayed if  `z >= tags->_minZoom`

Geometries that don't have the field `_minZoom` are displayed at every zoom level.