### PR TITLE
Compute Distribution of Presence Categories

### DIFF
--- a/app/analysis/boundaryStats.sql
+++ b/app/analysis/boundaryStats.sql
@@ -17,72 +17,9 @@ END;
 $$
 LANGUAGE plpgsql;
 
--- STEP 1: quantize bikelane data into points
-CREATE temp TABLE _bikelanesQuantized AS
-SELECT
-    osm_id,
-    tags,
-(atlas_QuantizeLineString(geom, 100)).* AS geom
-FROM
-    bikelanes;
-
--- STEP 2: calculate the distribution of our `category` for each area of the `boundary` data set
--- create a geospatial index on `_bikelanesQuantized` to speed up the spatial join;
-CREATE INDEX "_bikelanes_stats_geom_idx" ON _bikelanesQuantized USING gist(geom);
-
--- make `osm_id` the primary of the `bikelaneCategoryStats` to speed up group by
-ALTER TABLE "bikelaneCategoryStats"
-    DROP CONSTRAINT IF EXISTS category_stats_key;
-
-ALTER TABLE "bikelaneCategoryStats"
-    ADD CONSTRAINT category_stats_key PRIMARY KEY (osm_id);
-
--- spatialy join `_bikelanesQuantized` with `bikelaneCategoryStats` then group by category and bikelaneCategoryStats.osm_id to aggreagate the results in a single json object per area
-WITH stats AS (
-    SELECT
-        osm_id,
-        jsonb_object_agg(CONCAT(category, '_km'), len) AS bikelane_categories
-    FROM (
-        SELECT
-            boundary.osm_id AS osm_id,
-            bikelane.tags ->> 'category' AS category,
-            round(sum(bikelane.len) / 1000, 1) AS len
-        FROM
-            "bikelaneCategoryStats" AS boundary
-            JOIN _bikelanesQuantized AS bikelane ON ST_Intersects(boundary.geom, bikelane.geom)
-        GROUP BY
-            boundary.osm_id,
-            bikelane.tags ->> 'category') AS sq
-    GROUP BY
-        osm_id)
-UPDATE
-    "bikelaneCategoryStats"
-SET
-    bikelane_categories = stats.bikelane_categories
-FROM
-    stats
-WHERE
-    "bikelaneCategoryStats".osm_id = stats.osm_id;
-
--- -- for `jsonb` with numeric values return a normalized object (all values sum to 100) which also includes the total value
--- CREATE OR REPLACE FUNCTION atlas_NormalizeDistribution(dist jsonb)
---     RETURNS jsonb
---     AS $$
--- DECLARE
---     total numeric := sum(value)
--- FROM (
---     SELECT
---         (jsonb_each(dist)).value::numeric) AS sq;
--- BEGIN
---     RETURN jsonb_object_agg(key, round((100 * value::numeric) / total, 2)) || jsonb_build_object('total', total)
--- FROM (
---     SELECT
---         (jsonb_each(dist)).*) AS sq;
--- END;
--- $$
--- LANGUAGE plpgsql;
 
 -- presence stats:
+-- STEP 1: Quantize linestrings into points corresponding to 100m segments
 CREATE temp TABLE _roadsQuantized AS
 SELECT
     osm_id,
@@ -92,6 +29,9 @@ FROM
     roads
    where tags?'bikelane_self';
 
+
+-- STEP 2: prepare the data for a spatial join e.g. create a geomtric index and make `osm_id` the primary key
+-- create a geospatial index on `_roadsQuantized` to speed up the spatial join;
 CREATE INDEX "_roads_stats_geom_idx" ON _roadsQuantized USING gist(geom);
 
 -- make `osm_id` the primary of the `presenceStats` to speed up group by
@@ -101,6 +41,7 @@ ALTER TABLE "presenceStats"
 ALTER TABLE "presenceStats"
     ADD CONSTRAINT presence_stats_key PRIMARY KEY (osm_id);
 
+-- STEP 3: calculate the distribution of our `presence` data for each area of the `boundary` data set
 WITH stats AS (
     SELECT
         osm_id,
@@ -126,3 +67,70 @@ FROM
     stats
 WHERE
     "presenceStats".osm_id = stats.osm_id;
+
+
+-- -- bikelane category stats:
+-- -- STEP 1: quantize bikelane data into points
+-- CREATE temp TABLE _bikelanesQuantized AS
+-- SELECT
+--     osm_id,
+--     tags,
+-- (atlas_QuantizeLineString(geom, 100)).* AS geom
+-- FROM
+--     bikelanes;
+
+-- -- STEP 2: calculate the distribution of our `category` for each area of the `boundary` data set
+-- -- create a geospatial index on `_bikelanesQuantized` to speed up the spatial join;
+-- CREATE INDEX "_bikelanes_stats_geom_idx" ON _bikelanesQuantized USING gist(geom);
+
+-- -- make `osm_id` the primary of the `bikelaneCategoryStats` to speed up group by
+-- ALTER TABLE "bikelaneCategoryStats"
+--     DROP CONSTRAINT IF EXISTS category_stats_key;
+
+-- ALTER TABLE "bikelaneCategoryStats"
+--     ADD CONSTRAINT category_stats_key PRIMARY KEY (osm_id);
+
+-- -- spatialy join `_bikelanesQuantized` with `bikelaneCategoryStats` then group by category and bikelaneCategoryStats.osm_id to aggreagate the results in a single json object per area
+-- WITH stats AS (
+--     SELECT
+--         osm_id,
+--         jsonb_object_agg(CONCAT(category, '_km'), len) AS bikelane_categories
+--     FROM (
+--         SELECT
+--             boundary.osm_id AS osm_id,
+--             bikelane.tags ->> 'category' AS category,
+--             round(sum(bikelane.len) / 1000, 1) AS len
+--         FROM
+--             "bikelaneCategoryStats" AS boundary
+--             JOIN _bikelanesQuantized AS bikelane ON ST_Intersects(boundary.geom, bikelane.geom)
+--         GROUP BY
+--             boundary.osm_id,
+--             bikelane.tags ->> 'category') AS sq
+--     GROUP BY
+--         osm_id)
+-- UPDATE
+--     "bikelaneCategoryStats"
+-- SET
+--     bikelane_categories = stats.bikelane_categories
+-- FROM
+--     stats
+-- WHERE
+--     "bikelaneCategoryStats".osm_id = stats.osm_id;
+
+-- -- for `jsonb` with numeric values return a normalized object (all values sum to 100) which also includes the total value
+-- CREATE OR REPLACE FUNCTION atlas_NormalizeDistribution(dist jsonb)
+--     RETURNS jsonb
+--     AS $$
+-- DECLARE
+--     total numeric := sum(value)
+-- FROM (
+--     SELECT
+--         (jsonb_each(dist)).value::numeric) AS sq;
+-- BEGIN
+--     RETURN jsonb_object_agg(key, round((100 * value::numeric) / total, 2)) || jsonb_build_object('total', total)
+-- FROM (
+--     SELECT
+--         (jsonb_each(dist)).*) AS sq;
+-- END;
+-- $$
+-- LANGUAGE plpgsql;

--- a/app/analysis/boundaryStats.sql
+++ b/app/analysis/boundaryStats.sql
@@ -30,14 +30,14 @@ FROM
 -- create a geospatial index on `_bikelanesQuantized` to speed up the spatial join;
 CREATE INDEX "_bikelanes_stats_geom_idx" ON _bikelanesQuantized USING gist(geom);
 
--- make `osm_id` the primary of the `boundaryStats` to speed up group by
-ALTER TABLE "boundaryStats"
-    DROP CONSTRAINT IF EXISTS osm_id_key;
+-- make `osm_id` the primary of the `categoryStats` to speed up group by
+ALTER TABLE "categoryStats"
+    DROP CONSTRAINT IF EXISTS category_stats_key;
 
-ALTER TABLE "boundaryStats"
-    ADD CONSTRAINT osm_id_key PRIMARY KEY (osm_id);
+ALTER TABLE "categoryStats"
+    ADD CONSTRAINT category_stats_key PRIMARY KEY (osm_id);
 
--- spatialy join `_bikelanesQuantized` with `boundaryStats` then group by category and boundaryStats.osm_id to aggreagate the results in a single json object per area
+-- spatialy join `_bikelanesQuantized` with `categoryStats` then group by category and categoryStats.osm_id to aggreagate the results in a single json object per area
 WITH stats AS (
     SELECT
         osm_id,
@@ -48,7 +48,7 @@ WITH stats AS (
             bikelane.tags ->> 'category' AS category,
             round(sum(bikelane.len) / 1000, 1) AS len
         FROM
-            "boundaryStats" AS boundary
+            "categoryStats" AS boundary
             JOIN _bikelanesQuantized AS bikelane ON ST_Intersects(boundary.geom, bikelane.geom)
         GROUP BY
             boundary.osm_id,
@@ -56,13 +56,13 @@ WITH stats AS (
     GROUP BY
         osm_id)
 UPDATE
-    "boundaryStats"
+    "categoryStats"
 SET
     bikelane_categories = stats.bikelane_categories
 FROM
     stats
 WHERE
-    "boundaryStats".osm_id = stats.osm_id;
+    "categoryStats".osm_id = stats.osm_id;
 
 -- -- for `jsonb` with numeric values return a normalized object (all values sum to 100) which also includes the total value
 -- CREATE OR REPLACE FUNCTION atlas_NormalizeDistribution(dist jsonb)
@@ -82,7 +82,7 @@ WHERE
 -- $$
 -- LANGUAGE plpgsql;
 
--- Completnes stats:
+-- presence stats:
 CREATE temp TABLE _roadsQuantized AS
 SELECT
     osm_id,
@@ -94,24 +94,24 @@ FROM
 
 CREATE INDEX "_roads_stats_geom_idx" ON _roadsQuantized USING gist(geom);
 
--- make `osm_id` the primary of the `boundaryStats` to speed up group by
-ALTER TABLE "boundaryStats"
-    DROP CONSTRAINT IF EXISTS osm_id_key;
+-- make `osm_id` the primary of the `presenceStats` to speed up group by
+ALTER TABLE "presenceStats"
+    DROP CONSTRAINT IF EXISTS presence_stats_key;
 
-ALTER TABLE "boundaryStats"
-    ADD CONSTRAINT osm_id_key PRIMARY KEY (osm_id);
+ALTER TABLE "presenceStats"
+    ADD CONSTRAINT presence_stats_key PRIMARY KEY (osm_id);
 
 WITH stats AS (
     SELECT
         osm_id,
-        jsonb_object_agg(CONCAT(category, '_km'), len) AS completeness_categories
+        jsonb_object_agg(CONCAT(category, '_km'), len) AS presence_categories
     FROM (
         SELECT
             boundary.osm_id AS osm_id,
             roads.tags ->> unnest(Array['bikelane_left', 'bikelane_right', 'bikelane_self']) AS category,
             round(sum(roads.len) / 1000, 1) AS len
         FROM
-            "boundaryStats" AS boundary
+            "presenceStats" AS boundary
             JOIN _roadsQuantized AS roads ON ST_Intersects(boundary.geom, roads.geom)
         GROUP BY
             boundary.osm_id,
@@ -119,10 +119,10 @@ WITH stats AS (
     GROUP BY
         osm_id)
 UPDATE
-    "boundaryStats"
+    "presenceStats"
 SET
-    completeness_categories = stats.completeness_categories
+    presence_categories = stats.presence_categories
 FROM
     stats
 WHERE
-    "boundaryStats".osm_id = stats.osm_id;
+    "presenceStats".osm_id = stats.osm_id;

--- a/app/process/boundaries/boundaries.lua
+++ b/app/process/boundaries/boundaries.lua
@@ -23,8 +23,8 @@ local labelTable = osm2pgsql.define_table({
   }
 })
 
-local categoryStats = osm2pgsql.define_table({
-  name = 'categoryStats',
+local bikelaneCategoryStats = osm2pgsql.define_table({
+  name = 'bikelaneCategoryStats',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
     { column = 'tags',                type = 'jsonb' },
@@ -94,7 +94,7 @@ function osm2pgsql.process_relation(object)
 
   local admin_levels = Set({ "4", "6", "7", "8" })
   if admin_levels[tags.admin_level] then
-    categoryStats:insert({
+    bikelaneCategoryStats:insert({
       tags = results,
       meta = Metadata(object),
       geom = object:as_multipolygon()

--- a/app/process/boundaries/boundaries.lua
+++ b/app/process/boundaries/boundaries.lua
@@ -23,16 +23,16 @@ local labelTable = osm2pgsql.define_table({
   }
 })
 
-local bikelaneCategoryStats = osm2pgsql.define_table({
-  name = 'bikelaneCategoryStats',
-  ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
-  columns = {
-    { column = 'tags',                type = 'jsonb' },
-    { column = 'meta',                type = 'jsonb' },
-    { column = 'bikelane_categories', type = 'jsonb',       create_only = true },
-    { column = 'geom',                type = 'multipolygon' },
-  }
-})
+-- local bikelaneCategoryStats = osm2pgsql.define_table({
+--   name = 'bikelaneCategoryStats',
+--   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+--   columns = {
+--     { column = 'tags',                type = 'jsonb' },
+--     { column = 'meta',                type = 'jsonb' },
+--     { column = 'bikelane_categories', type = 'jsonb',       create_only = true },
+--     { column = 'geom',                type = 'multipolygon' },
+--   }
+-- })
 
 local presenceStats = osm2pgsql.define_table({
   name = 'presenceStats',
@@ -92,14 +92,14 @@ function osm2pgsql.process_relation(object)
     geom = object:as_multipolygon():centroid()
   })
 
-  local admin_levels = Set({ "4", "6", "7", "8" })
-  if admin_levels[tags.admin_level] then
-    bikelaneCategoryStats:insert({
-      tags = results,
-      meta = Metadata(object),
-      geom = object:as_multipolygon()
-    })
-  end
+  -- local admin_levels = Set({ "4", "6", "7", "8" })
+  -- if admin_levels[tags.admin_level] then
+  --   bikelaneCategoryStats:insert({
+  --     tags = results,
+  --     meta = Metadata(object),
+  --     geom = object:as_multipolygon()
+  --   })
+  -- end
   if results.category_district or results.category_municipality then
     presenceStats:insert({
       tags = results,

--- a/app/process/boundaries/boundaries.lua
+++ b/app/process/boundaries/boundaries.lua
@@ -23,13 +23,24 @@ local labelTable = osm2pgsql.define_table({
   }
 })
 
-local statsTable = osm2pgsql.define_table({
-  name = 'boundaryStats',
+local categoryStats = osm2pgsql.define_table({
+  name = 'categoryStats',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
     { column = 'tags',                type = 'jsonb' },
     { column = 'meta',                type = 'jsonb' },
     { column = 'bikelane_categories', type = 'jsonb',       create_only = true },
+    { column = 'geom',                type = 'multipolygon' },
+  }
+})
+
+local presenceStats = osm2pgsql.define_table({
+  name = 'presenceStats',
+  ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+  columns = {
+    { column = 'tags',                type = 'jsonb' },
+    { column = 'meta',                type = 'jsonb' },
+    { column = 'presence_categories', type = 'jsonb',       create_only = true },
     { column = 'geom',                type = 'multipolygon' },
   }
 })
@@ -83,7 +94,14 @@ function osm2pgsql.process_relation(object)
 
   local admin_levels = Set({ "4", "6", "7", "8" })
   if admin_levels[tags.admin_level] then
-    statsTable:insert({
+    categoryStats:insert({
+      tags = results,
+      meta = Metadata(object),
+      geom = object:as_multipolygon()
+    })
+  end
+  if results.category_district or results.category_municipality then
+    presenceStats:insert({
       tags = results,
       meta = Metadata(object),
       geom = object:as_multipolygon()


### PR DESCRIPTION
This PR replaces our analysis of the bikelane categories with an analysis of the presence categories.
The method is almost identically with the only change being that we have the values per considered road (`left`, `self`, `right` ). That means that the total summ of all categories corresponds to three times the length of the considered roads network. 
Due to that these values should only be considered relatively e.g. as a distribution...