### PR TITLE
Unnest `cycleway` Tags on all Paths ✅ 

### DIFF
--- a/processing/topics/roads_bikelanes/__tests__/Bikelanes.test.lua
+++ b/processing/topics/roads_bikelanes/__tests__/Bikelanes.test.lua
@@ -4,7 +4,7 @@ describe("Bikelanes", function()
   require("osm2pgsql")
   require("Bikelanes")
 
-  describe('Handle `width`', function()
+  describe('Handle `width`:', function()
     it('handels width on centerline', function()
       local input_object = {
         tags = {
@@ -16,8 +16,8 @@ describe("Bikelanes", function()
         type = 'way'
       }
       local result = Bikelanes(input_object)
-      assert.are.same(result[1].category, "bicycleRoad")
-      assert.are.same(result[1].width, 5)
+      assert.are.equal(result[1].category, "bicycleRoad")
+      assert.are.equal(result[1].width, 5)
     end)
 
     it('handels explicit width on transformed objects', function()
@@ -32,7 +32,27 @@ describe("Bikelanes", function()
         type = 'way'
       }
       local result = Bikelanes(input_object)
-      -- Add assertions here
+      assert.are.equal(result[1].category, "cycleway_adjoining")
+      assert.are.equal(result[1].width, 5)
+    end)
+
+    it('handels nested width on paths', function()
+      local input_object = {
+        tags = {
+          highway = 'path',
+          bicycle = 'yes',
+          foot = 'yes',
+          segreagated = 'yes',
+          segregated = "yes",
+          is_sidepath = "yes",
+          ['cycleway:width'] = '5 m',
+        },
+        id = 1,
+        type = 'way'
+      }
+      local result = Bikelanes(input_object)
+      assert.are.equal(result[1].category, "cycleway_adjoining")
+      assert.are.equal(result[1].width, 5)
     end)
   end)
 end)

--- a/processing/topics/roads_bikelanes/__tests__/Bikelanes.test.lua
+++ b/processing/topics/roads_bikelanes/__tests__/Bikelanes.test.lua
@@ -42,7 +42,6 @@ describe("Bikelanes", function()
           highway = 'path',
           bicycle = 'yes',
           foot = 'yes',
-          segreagated = 'yes',
           segregated = "yes",
           is_sidepath = "yes",
           ['cycleway:width'] = '5 m',

--- a/processing/topics/roads_bikelanes/bikelanes/transformations.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/transformations.lua
@@ -45,13 +45,13 @@ function GetTransformedObjects(tags, transformations)
   local center = MergeTable({}, tags)
   center._side = "self"
   center._prefix = ""
+  -- don't transform paths only unnest tags prefixed with `cycleway`
+  if PathClasses[tags.highway] or tags.highway == 'pedestrian' then
+    unnestTags(tags, 'cycleway', '', center)
+    return { center }
+  end
 
   local results = { center }
-
-  -- don't transform paths
-  if PathClasses[tags.highway] or tags.highway == 'pedestrian' then
-    return results
-  end
   for _, transformation in ipairs(transformations) do
     for _, side in ipairs({ "left", "right" }) do
       if tags.highway ~= transformation.highway then


### PR DESCRIPTION
This PR add unnesting for all paths for tags being prefixed with `cycleway` . 
Solves [#1408](https://github.com/FixMyBerlin/private-issues/issues/1408)