### PR TITLE
Add Diffing without Changing the Data 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ SKIP_TAG_FILTER=0 # skips tag filtering
 SKIP_WARM_CACHE=1 # skips cache warming
 WAIT_FOR_FRESH_DATA=0 # waits till the given file is from today
 ID_FILTER='' # if not empty only the objects with these ids are processed. Ids need to be prefixed with the oms_type, see https://docs.osmcode.org/osmium/latest/osmium-getid.html
-COMPUTE_DIFFS=1 # whether to create diff tables or not
+COMPUTE_DIFFS=1 # if `1` compute diffs and update data. If `2` only compute the diffs and make no changes to the data
 
 # Token for Synology log. Leave blank to disable logging
 SYNOLOGY_LOG_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@ SKIP_TAG_FILTER=0 # skips tag filtering
 SKIP_WARM_CACHE=1 # skips cache warming
 WAIT_FOR_FRESH_DATA=0 # waits till the given file is from today
 ID_FILTER='' # if not empty only the objects with these ids are processed. Ids need to be prefixed with the oms_type, see https://docs.osmcode.org/osmium/latest/osmium-getid.html
-COMPUTE_DIFFS=1 # wether to create diff tables or not
-FREEZE_DATA=0 # wether to surpress updating the tables. Works only in combination with `COMPUTE_DIFFS=1`
+COMPUTE_DIFFS=1 # whether to create diff tables or not
+FREEZE_DATA=0 # whether to surpress updating the tables. Works only in combination with `COMPUTE_DIFFS=1`
 
 # Token for Synology log. Leave blank to disable logging
 SYNOLOGY_LOG_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,8 @@ SKIP_TAG_FILTER=0 # skips tag filtering
 SKIP_WARM_CACHE=1 # skips cache warming
 WAIT_FOR_FRESH_DATA=0 # waits till the given file is from today
 ID_FILTER='' # if not empty only the objects with these ids are processed. Ids need to be prefixed with the oms_type, see https://docs.osmcode.org/osmium/latest/osmium-getid.html
-COMPUTE_DIFFS=1 # if `1` compute diffs and update data. If `2` only compute the diffs and make no changes to the data
+COMPUTE_DIFFS=1 # wether to create diff tables or not
+FREEZE_DATA=0 # wether to surpress updating the tables. Works only in combination with `COMPUTE_DIFFS=1`
 
 # Token for Synology log. Leave blank to disable logging
 SYNOLOGY_LOG_TOKEN=

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Whenever `SKIP_DOWNLOAD=1` and `COMPUTE_DIFFS=1`, the system will create `<table
 
 It will compare the `tags` column to the previous run.
 
-The settings are the default for development but disabled on staging, production by default.
-
 Whenever we talk about `diff`s in this code, this feature is referenced.
+
+With `FREEZE_DATA=1` the system will **not** update the tables. This is usefull during development if one only wants to see the changes to a certain version. This flag will be ignored if `COMPUTE_DIFFS=0`.
 
 ### Process only a single object
 

--- a/app/diffing/compute_diff.sh
+++ b/app/diffing/compute_diff.sh
@@ -1,0 +1,82 @@
+
+#!/bin/bash
+source /app/utils/logging.sh
+
+# Create functions needed for jsonb diffs
+psql -q -f /app/diffing/JSONDiff.sql &> /dev/null
+
+# (private function used by run_dir)
+compute_diff() {
+  backup_table=$1_backup
+  table=$1
+  diff_table=$1_diff
+
+  psql -q -c "DROP TABLE IF EXISTS \"$diff_table\";" &> /dev/null
+
+  columns="tags, osm_id, meta, geom"
+
+  # Compute diff of `tags` column using `jsonb_diff` from `JSONDiff.sql`
+  query="
+    SELECT $columns
+    INTO \"$diff_table\"
+    FROM (
+      SELECT
+        jsonb_diff(\"$backup_table\".tags, \"$table\".tags) AS tags,
+        \"$table\".osm_id, \"$table\".meta, \"$table\".geom
+      FROM \"$table\"
+      JOIN \"$backup_table\"
+        ON \"$table\".osm_id = \"$backup_table\".osm_id
+    ) sq
+    WHERE tags != '{}'::jsonb;
+    UPDATE  \"$diff_table\" SET tags = tags || '{\"CHANGE\": \"modified\"}'::jsonb;
+    SELECT count(osm_id) FROM \"$diff_table\";"
+  n_modified=$(echo $query | psql -q -t -A)
+
+  # Add new rows to diff table
+  query="
+    CREATE TEMP TABLE added_rows AS
+      SELECT
+        jsonb_prefix_values(\"$table\".tags, '(+)') as tags,
+        \"$table\".osm_id,
+        \"$table\".meta,
+        \"$table\".geom
+      FROM \"$table\"
+      FULL OUTER JOIN \"$backup_table\"
+        ON \"$table\".osm_id = \"$backup_table\".osm_id
+      WHERE \"$backup_table\".osm_id IS NULL;
+    UPDATE  added_rows SET tags = tags || '{\"CHANGE\": \"added\"}'::jsonb;
+    SELECT count(*) FROM added_rows;
+    INSERT INTO \"$diff_table\" SELECT $columns FROM added_rows;"
+  n_added=$(echo $query | psql -q -t -A)
+
+  # Add delted rows to diff table
+  query="
+    CREATE TEMP TABLE deleted_rows AS
+      SELECT
+        jsonb_prefix_values(\"$backup_table\".tags, '(-)') || jsonb_build_object('CHANGE', 'deleted') as tags,
+        \"$backup_table\".osm_id,
+        \"$backup_table\".meta,
+        \"$backup_table\".geom
+      FROM \"$backup_table\"
+      FULL OUTER JOIN \"$table\"
+        ON \"$backup_table\".osm_id = \"$table\".osm_id
+      WHERE \"$table\".osm_id IS NULL;
+    UPDATE  deleted_rows SET tags = tags || '{\"CHANGE\": \"deleted\"}'::jsonb;
+    SELECT count(*) FROM deleted_rows;
+    INSERT INTO \"$diff_table\" SELECT $columns FROM deleted_rows;"
+  n_deleted=$(echo $query | psql -q -t -A)
+
+  # TODO: write as table _comment_.
+  n_changes=$(psql -t -A -c "SELECT count(*) FROM \"$diff_table\";")
+  if [ "$n_changes" == 0 ]; then
+    log "$n_changes changes in $table."
+    # Cleanup
+    psql -q -c "DROP TABLE \"$diff_table\";"
+  else
+    log "$n_changes changes in $table:"
+    log "    $n_added entries added."
+    log "    $n_deleted entries deleted."
+    log "    $n_modified entries modified."
+  fi
+
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       SYNOLOGY_LOG_TOKEN:
       SYNOLOGY_ERROR_LOG_TOKEN:
       COMPUTE_DIFFS:
+      FREEZE_DATA:
     volumes:
       - osmfiles:/data
       - geodata:/data/db

--- a/processing/process-helpers.sh
+++ b/processing/process-helpers.sh
@@ -77,7 +77,7 @@ run_dir() {
     fi
   else
     # Backup tables for diffs
-    if [ "$COMPUTE_DIFFS" == 1 ] || [ "$COMPUTE_DIFFS" == 2 ]; then
+    if [ "$COMPUTE_DIFFS" == 1 ]; then
       if [ -f "$processed_tables" ]; then
         for table in $(cat $processed_tables); do # iterate over tables from last run
           psql -q -c "DROP TABLE IF EXISTS \"${table}_backup\";" &> /dev/null
@@ -100,15 +100,15 @@ run_dir() {
     # Create diffs for all backedup tables that where already available
     if [ -f $backedup_tables ]; then
       log_start "Compute Diffs"
-      log "Computing diffs (.env 'COMPUTE_DIFFS=1|2') for: $(tr '\n' ' ' < $backedup_tables)"
+      log "Computing diffs (.env 'COMPUTE_DIFFS=1') for: $(tr '\n' ' ' < $backedup_tables)"
       for table in $(cat $backedup_tables); do
         if grep -q -E "^${table}\$" $processed_tables; then
           compute_diff $table
         else
           log "$table got deleted."
         fi
-        if [ "$COMPUTE_DIFFS" == 2 ]; then
-          log "Restoring data. (.env 'COMPUTE_DIFFS = 2')"
+        if [ "$FREEZE_DATA" == 1 ]; then
+          log "Restoring data. (.env 'FREEZE_DATA=1')"
           psql -q -c "DROP TABLE \"${table}\";"
           psql -q -c "ALTER TABLE \"${table}_backup\" RENAME TO \"${table}\";"
           mv -f $backedup_tables $processed_tables

--- a/processing/process-helpers.sh
+++ b/processing/process-helpers.sh
@@ -77,7 +77,7 @@ run_dir() {
     fi
   else
     # Backup tables for diffs
-    if [ "$COMPUTE_DIFFS" == 1 ]; then
+    if [ "$COMPUTE_DIFFS" == 1 ] || [ "$COMPUTE_DIFFS" == 2 ]; then
       if [ -f "$processed_tables" ]; then
         for table in $(cat $processed_tables); do # iterate over tables from last run
           psql -q -c "DROP TABLE IF EXISTS \"${table}_backup\";" &> /dev/null
@@ -100,14 +100,20 @@ run_dir() {
     # Create diffs for all backedup tables that where already available
     if [ -f $backedup_tables ]; then
       log_start "Compute Diffs"
-      log "Computing diffs (.env 'COMPUTE_DIFFS=1') for: $(tr '\n' ' ' < $backedup_tables)"
+      log "Computing diffs (.env 'COMPUTE_DIFFS=1|2') for: $(tr '\n' ' ' < $backedup_tables)"
       for table in $(cat $backedup_tables); do
         if grep -q -E "^${table}\$" $processed_tables; then
           compute_diff $table
         else
           log "$table got deleted."
         fi
-        psql -q -c "DROP TABLE \"${table}_backup\";"
+        if [ "$COMPUTE_DIFFS" == 2 ]; then
+          log "Restoring data. (.env 'COMPUTE_DIFFS = 2')"
+          psql -q -c "DROP TABLE \"${table}\";"
+          psql -q -c "ALTER TABLE \"${table}_backup\" RENAME TO \"${table}\";"
+        else
+          psql -q -c "DROP TABLE \"${table}_backup\";"
+        fi
       done
       rm $backedup_tables
       log_end "Compute Diffs"

--- a/processing/process-helpers.sh
+++ b/processing/process-helpers.sh
@@ -111,6 +111,7 @@ run_dir() {
           log "Restoring data. (.env 'COMPUTE_DIFFS = 2')"
           psql -q -c "DROP TABLE \"${table}\";"
           psql -q -c "ALTER TABLE \"${table}_backup\" RENAME TO \"${table}\";"
+          mv -f $backedup_tables $processed_tables
         else
           psql -q -c "DROP TABLE \"${table}_backup\";"
         fi

--- a/processing/process-helpers.sh
+++ b/processing/process-helpers.sh
@@ -108,15 +108,18 @@ run_dir() {
           log "$table got deleted."
         fi
         if [ "$FREEZE_DATA" == 1 ]; then
-          log "Restoring data. (.env 'FREEZE_DATA=1')"
           psql -q -c "DROP TABLE \"${table}\";"
           psql -q -c "ALTER TABLE \"${table}_backup\" RENAME TO \"${table}\";"
-          mv -f $backedup_tables $processed_tables
         else
           psql -q -c "DROP TABLE \"${table}_backup\";"
         fi
       done
-      rm $backedup_tables
+      if [ "$FREEZE_DATA" == 1 ]; then
+        log "Restored data (.env 'FREEZE_DATA=1')"
+        mv -f $backedup_tables $processed_tables
+      else
+        rm $backedup_tables
+      fi
       log_end "Compute Diffs"
     fi
   fi

--- a/processing/run.sh
+++ b/processing/run.sh
@@ -9,6 +9,7 @@ export OSM_FILTERED_FILE=${OSM_DATADIR}openstreetmap-filtered.osm.pbf
 # define default args
 export SKIP_DOWNLOAD=${SKIP_DOWNLOAD:-0}
 export SKIP_TAG_FILTER=${SKIP_TAG_FILTER:-0}
+export COMPUTE_DIFFS=${COMPUTE_DIFFS:-0}
 export ID_FILTER=${ID_FILTER:-''}
 export SYNOLOGY_URL='https://fixmy.diskstation.me:54545/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=2&token='
 

--- a/processing/run.sh
+++ b/processing/run.sh
@@ -10,6 +10,7 @@ export OSM_FILTERED_FILE=${OSM_DATADIR}openstreetmap-filtered.osm.pbf
 export SKIP_DOWNLOAD=${SKIP_DOWNLOAD:-0}
 export SKIP_TAG_FILTER=${SKIP_TAG_FILTER:-0}
 export COMPUTE_DIFFS=${COMPUTE_DIFFS:-0}
+export FREEZE_DATA=${FREEZE_DATA:-0}
 export ID_FILTER=${ID_FILTER:-''}
 export SYNOLOGY_URL='https://fixmy.diskstation.me:54545/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=2&token='
 


### PR DESCRIPTION
This PR adds a new option for creating diffs without actually updating our tables. This is very practical during development, as it allows us to always create the diffs to the same version of the data.
This could also be incorporated into a GH action.