### PR TITLE
Bikelane categories: Living street

### DIFF
--- a/processing/topics/roads_bikelanes/bikelanes/BikelaneCategories.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/BikelaneCategories.lua
@@ -61,32 +61,27 @@ local pedestrianAreaBicycleYes = BikelaneCategories.new({
       ' explicit allowance for bicycles (`bicycle=yes`). `dismount` counts as `no`.' ..
       ' (We only process the ways, not the `area=yes` Polygon.)',
   categorization = function(tags)
-    if tags.highway == "pedestrian" and tags.bicycle == "yes" then
+    if tags.highway == "pedestrian" and (tags.bicycle == "yes" or tags.bicycle == "designated") then
       return "pedestrianAreaBicycleYes"
     end
   end
 })
 
--- Handle `highway=living_street`
--- DE: Verkehrsberuhigter Bereich AKA "Spielstraße"
 -- https://wiki.openstreetmap.org/wiki/DE:Tag:highway=living_street
 local livingStreet = BikelaneCategories.new({
-  desc = '', -- TODO desc
+  desc = 'Living streets are considered bike friendly and added unless prohibided.' ..
+      ' (DE: "Verkehrsberuhigter Bereich" AKA "Spielstraße")',
   categorization = function(tags)
     if tags.highway == "living_street" then
-      -- TODO: Research the default access for bikes in living streets. Check the tags used in DB for "bicycle".
-      -- No vehicle except bicycles
-      -- TODO: This condition is wrong. It has to be…
-      -- if tags.vehicle == "no" and tags.bicycle == "yes" then
-      if tags.vehicle == "no" and not tags.bicycle == "yes" then
-        return "livingStreet"
+      -- Exit if all vehicle are prohibited (but not bikes)
+      if tags.vehicle == "no" and not (tags.bicycle == "yes" or tags.bicycle == "designated") then
+        return nil
       end
-      -- Nothing about vehicle but bicycle=yes or similar
-      -- TODO: This condition is wrong. It has to be…
-      -- if tags.bicycle == "yes" or tags.bicycle == "destination" then
-      if (tags.vehicle == nil or tags.vehicle == "yes") and not tags.bicycle == "no" then
-        return "livingStreet"
+      -- Exit if bikes are prohibited
+      if tags.bicycle == "no" or tags.bicycle == "dismount" then
+        return nil
       end
+      return "livingStreet"
     end
   end
 })

--- a/processing/topics/roads_bikelanes/bikelanes/BikelaneCategories.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/BikelaneCategories.lua
@@ -4,26 +4,26 @@ require("IsTermInString")
 require("IsSidepath")
 require("AddAdjoiningOrIsolated")
 require("SanitizeTrafficSign")
-BikelaneCategories = {}
-BikelaneCategories.__index = BikelaneCategories
+BikelaneCategory = {}
+BikelaneCategory.__index = BikelaneCategory
 
 -- @param args table
 -- @param args.desc string
--- @param args.categorization function
-function BikelaneCategories.new(args)
-  local self = setmetatable({}, BikelaneCategories)
+-- @param args.condition function
+function BikelaneCategory.new(args)
+  local self = setmetatable({}, BikelaneCategory)
   self.desc = args.desc
-  self.categorization = args.categorization
+  self.condition = args.condition
   return self
 end
 
-function BikelaneCategories:checkCondition(tags)
-  return self.categorization(tags)
+function BikelaneCategory:checkCondition(tags)
+  return self.condition(tags)
 end
 
-local dataNo = BikelaneCategories.new({
+local dataNo = BikelaneCategory.new({
   desc = 'The explicit absence of bike infrastrucute',
-  categorization = function(tags)
+  condition = function(tags)
     local nos = Set({ 'no', 'none' })
     if nos[tags.cycleway] then
       return "data_no"
@@ -31,9 +31,9 @@ local dataNo = BikelaneCategories.new({
   end
 })
 
-local isSeparate = BikelaneCategories.new({
+local isSeparate = BikelaneCategory.new({
   desc = '',
-  categorization = function(tags)
+  condition = function(tags)
     if tags.cycleway == 'separate' then
       return 'separate_geometry'
     end
@@ -42,9 +42,9 @@ local isSeparate = BikelaneCategories.new({
 
 -- for oneways we assume that the tag `cycleway=*` significates that there's one bike line on the right
 -- TODO: this assumes right hand traffic (would be nice to specify this as an option)
-local implicitOneWay = BikelaneCategories.new({
+local implicitOneWay = BikelaneCategory.new({
   desc = '',
-  categorization = function(tags)
+  condition = function(tags)
     local result = tags._prefix == 'cycleway' and tags._infix == '' -- object is created from implicit case
     result = result and tags._parent.oneway == 'yes' and
         tags._parent['oneway:bicycle'] ~= 'no'                      -- is oneway w/o bike exception
@@ -56,11 +56,11 @@ local implicitOneWay = BikelaneCategories.new({
 })
 
 -- https://wiki.openstreetmap.org/wiki/DE:Tag:highway=pedestrian
-local pedestrianAreaBicycleYes = BikelaneCategories.new({
+local pedestrianAreaBicycleYes = BikelaneCategory.new({
   desc = 'Pedestrian area (DE:"Fußgängerzonen") with' ..
       ' explicit allowance for bicycles (`bicycle=yes`). `dismount` counts as `no`.' ..
       ' (We only process the ways, not the `area=yes` Polygon.)',
-  categorization = function(tags)
+  condition = function(tags)
     if tags.highway == "pedestrian" and (tags.bicycle == "yes" or tags.bicycle == "designated") then
       return "pedestrianAreaBicycleYes"
     end
@@ -68,10 +68,10 @@ local pedestrianAreaBicycleYes = BikelaneCategories.new({
 })
 
 -- https://wiki.openstreetmap.org/wiki/DE:Tag:highway=living_street
-local livingStreet = BikelaneCategories.new({
+local livingStreet = BikelaneCategory.new({
   desc = 'Living streets are considered bike friendly and added unless prohibided.' ..
       ' (DE: "Verkehrsberuhigter Bereich" AKA "Spielstraße")',
-  categorization = function(tags)
+  condition = function(tags)
     if tags.highway == "living_street" then
       -- Exit if all vehicle are prohibited (but not bikes)
       if tags.vehicle == "no" and not (tags.bicycle == "yes" or tags.bicycle == "designated") then
@@ -88,10 +88,10 @@ local livingStreet = BikelaneCategories.new({
 
 -- https://wiki.openstreetmap.org/wiki/DE:Key:bicycle%20road
 -- traffic_sign=DE:244, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign=DE:244
-local bicycleRoadCases = BikelaneCategories.new({
+local bicycleRoadCases = BikelaneCategory.new({
   desc = 'Bicycle road (DE: "Fahrradstraße")' ..
       ' with subcategory for vehicle access `destination`.',
-  categorization = function(tags)
+  condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
     if tags.bicycle_road == "yes"
         or osm2pgsql.has_prefix(trafficSign, 'DE:244')
@@ -110,10 +110,10 @@ local bicycleRoadCases = BikelaneCategories.new({
 })
 
 -- traffic_sign=DE:240, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign=DE:240
-local footAndCyclewaySharedCases = BikelaneCategories.new({
+local footAndCyclewaySharedCases = BikelaneCategory.new({
   desc = 'Shared bike and foot path (DE: "Gemeinsamer Geh- und Radweg")' ..
       ' with subcategories for adjoining or isolated paths.',
-  categorization = function(tags)
+  condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
     local taggedWithAccessTagging = tags.bicycle == "designated" and tags.foot == "designated" and
         tags.segregated == "no"
@@ -128,10 +128,10 @@ local footAndCyclewaySharedCases = BikelaneCategories.new({
 
 -- traffic_sign=DE:241-30, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign=DE:241-30
 -- traffic_sign=DE:241-31, https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign=DE:241-31
-local footAndCyclewaySegregatedCases = BikelaneCategories.new({
+local footAndCyclewaySegregatedCases = BikelaneCategory.new({
   desc = 'Shared bike and foot path (DE: "Getrennter Geh- und Radweg", "Getrennter Rad- und Gehweg")' ..
       ' with subcategories for adjoining or isolated paths.',
-  categorization = function(tags)
+  condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
     local taggedWithAccessTagging = tags.bicycle == "designated" and tags.foot == "designated" and
         tags.segregated == "yes"
@@ -144,11 +144,11 @@ local footAndCyclewaySegregatedCases = BikelaneCategories.new({
 
 -- Case: "Gehweg, Fahrrad frei"
 -- traffic_sign=DE:1022-10 "Fahrrad frei", https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign=DE:239
-local footwayBicycleYesCases = BikelaneCategories.new({
+local footwayBicycleYesCases = BikelaneCategory.new({
   desc = 'Footway / Sidewalk with explicit allowance for bicycles (`bicycle=yes`)' ..
       ' (DE: "Gehweg, Fahrrad frei")' ..
       ' and subcategories for adjoining or isolated paths.',
-  categorization = function(tags)
+  condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
 
     -- mtb:scale=* is a strong indicator for path' that we do not want to show, so we skip them;
@@ -169,9 +169,9 @@ local footwayBicycleYesCases = BikelaneCategories.new({
 -- Handle different cases for separated bikelanes ("baulich abgesetzte Radwege")
 -- The sub-tagging specifies if the cycleway is part of a road or a separate way.
 -- This part relies heavly on the `is_sidepath` tagging.
-local cyclewaySeparatedCases = BikelaneCategories.new({
+local cyclewaySeparatedCases = BikelaneCategory.new({
   desc = '', -- TODO desc
-  categorization = function(tags)
+  condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
 
     -- Case "Hochbordradwege"
@@ -206,10 +206,10 @@ local cyclewaySeparatedCases = BikelaneCategories.new({
 })
 
 -- Examples https://github.com/FixMyBerlin/atlas-app/issues/23
-local crossing = BikelaneCategories.new({
+local crossing = BikelaneCategory.new({
   desc = 'Crossings with relevance for bicycles.' ..
       ' There is no split into more specific infrastrucute categories for now.',
-  categorization = function(tags)
+  condition = function(tags)
     if tags.highway == "cycleway" and tags.cycleway == "crossing" then
       return "crossing"
     end
@@ -224,11 +224,11 @@ local crossing = BikelaneCategories.new({
   end
 })
 
-local cyclewayLink = BikelaneCategories.new({
+local cyclewayLink = BikelaneCategory.new({
   desc = 'A non-infrastrucute category.' ..
       ' `cycleway=link` is used to connect the road network for routing use cases' ..
       ' when no physical infrastructure is present.',
-  categorization = function(tags)
+  condition = function(tags)
     if tags.highway == "cycleway" and tags.cycleway == "link" then
       return "cyclewayLink"
     end
@@ -238,11 +238,11 @@ local cyclewayLink = BikelaneCategories.new({
 -- https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway=lane
 -- https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway=opposite_lane
 -- https://wiki.openstreetmap.org/wiki/Key:cycleway:lane
-local cyclewayOnHighwayCases = BikelaneCategories.new({
+local cyclewayOnHighwayCases = BikelaneCategory.new({
   desc = 'Bicycle infrastrucute on the highway, right next to motor vehicle traffic.' ..
       ' This category is split into subcategories for "advisory" (DE: "Schutzstreifen")' ..
       ' and "exclusive" lanes (DE: "Radfahrstreifen").',
-  categorization = function(tags)
+  condition = function(tags)
     if tags.highway == 'cycleway' then
       if tags.cycleway == "lane" or tags.cycleway == "opposite_lane" then
         if tags['lane'] == 'advisory' then
@@ -259,9 +259,9 @@ local cyclewayOnHighwayCases = BikelaneCategories.new({
 
 -- Case: Cycleway identified via "shared_lane"-tagging ("Anteilig genutzten Fahrstreifen")
 -- https://wiki.openstreetmap.org/wiki/DE:Tag:cycleway=shared_lane
-local sharedMotorVehicleLane = BikelaneCategories.new({
+local sharedMotorVehicleLane = BikelaneCategory.new({
   desc = '', -- TODO desc; Wiki nochmal nachlesen und Conditions prüfen
-  categorization = function(tags)
+  condition = function(tags)
     local result = tags.highway == 'cycleway' and tags.cycleway == "shared_lane"
     if result then
       return "sharedMotorVehicleLane"
@@ -271,10 +271,10 @@ local sharedMotorVehicleLane = BikelaneCategories.new({
 
 -- https://wiki.openstreetmap.org/wiki/Forward_&_backward,_left_&_right
 -- https://wiki.openstreetmap.org/wiki/Lanes#Crossing_with_a_designated_lane_for_bicycles
-local cyclewayOnHighwayBetweenLanes = BikelaneCategories.new({
+local cyclewayOnHighwayBetweenLanes = BikelaneCategory.new({
   desc = 'Bike lane between motor vehicle lanes,' ..
       ' mostly on the left of a right turn lane. (DE: "Radweg in Mittellage")',
-  categorization = function(tags)
+  condition = function(tags)
     if tags['_parent_highway'] == nil or tags._prefix == 'sidewalk' then return end
 
     if IsTermInString("|lane|", tags['cycleway:lanes']) or
@@ -292,10 +292,10 @@ local cyclewayOnHighwayBetweenLanes = BikelaneCategories.new({
 --   - https://trafficsigns.osm-verkehrswende.org/?signs=DE%3A245%7CDE%3A1022-10%7CDE%3A1026-30
 -- "Fahrrad & Mofa frei" traffic_sign=DE:245,1022-14
 -- (History: Until 2023-03-2: cyclewayAlone)
-local sharedBusLaneBusWithBike = BikelaneCategories.new({
+local sharedBusLaneBusWithBike = BikelaneCategory.new({
   desc = 'Bus lane with explicit allowance for bicycles (`cycleway=share_busway`).' ..
       ' (DE: "Bussonderfahrstreifen mit Fahrrad frei")',
-  categorization = function(tags)
+  condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
     local taggedWithAccessTagging = tags.highway == "cycleway" and
         (tags.cycleway == "share_busway" or tags.cycleway == "opposite_share_busway")
@@ -315,10 +315,10 @@ local sharedBusLaneBusWithBike = BikelaneCategories.new({
 --   - 81 in DE https://taginfo.geofabrik.de/europe:germany/tags/cycleway%3Aright%3Alane=share_busway#overview
 --   - 87 overall https://taginfo.openstreetmap.org/tags/cycleway%3Aright%3Alane=share_busway#overview
 --   - 1 overall for left https://taginfo.openstreetmap.org/tags/cycleway%3Aleft%3Alane=share_busway#overview
-local sharedBusLaneBikeWithBus = BikelaneCategories.new({
+local sharedBusLaneBikeWithBus = BikelaneCategory.new({
   desc = 'Bicycle lane with explicit allowance for buses.' ..
       ' (DE: "Radfahrstreifen mit Freigabe Busverkehr")',
-  categorization = function(tags)
+  condition = function(tags)
     local trafficSign = SanitizeTrafficSign(tags.traffic_sign)
     local taggedWithAccessTagging = tags.highway == "cycleway" and tags.lane == "share_busway"
     local taggedWithTrafficsign =
@@ -336,9 +336,9 @@ local sharedBusLaneBikeWithBus = BikelaneCategories.new({
 -- Example https://www.openstreetmap.org/way/35396829/history
 --
 -- TODO: Remove this category and make it an exit conditino to "needsClarification"
-local sharedLane = BikelaneCategories.new({
+local sharedLane = BikelaneCategory.new({
   desc = '',
-  categorization = function(tags)
+  condition = function(tags)
     if tags.cycleway == "shared" then
       return "explicitSharedLaneButNoSignage"
     end
@@ -347,10 +347,10 @@ local sharedLane = BikelaneCategories.new({
 
 -- This is where we collect bike lanes that do not have sufficient tagging to be categorized well.
 -- They are in OSM, but they need to be improved, which we show in the UI.
-local needsClarification = BikelaneCategories.new({
+local needsClarification = BikelaneCategory.new({
   desc = 'Bike infrastructure that we cannot categories properly due to missing or ambiguous tagging.' ..
       ' Check the `todos` property on hints on how to improve the tagging.',
-  categorization = function(tags)
+  condition = function(tags)
     if tags.highway == "cycleway"
         or (tags.highway == "path" and tags.bicycle == "designated") then
       return "needsClarification"


### PR DESCRIPTION
This is based on top of https://github.com/FixMyBerlin/atlas-geo/pull/137

- [ ] Change PR base to "develop" before merging 

---

This adds quite a bit of data for Berlin-Brandenburg. But I think that is a good thing …

```
6606 changes in roads:
    0 entries added.
    0 entries deleted.
    6606 entries modified.
12 changes in roadsPathClasses:
    0 entries added.
    0 entries deleted.
    12 entries modified. – unrelated
6270 changes in bikelanes:
    6262 entries added.
    0 entries deleted.
    8 entries modified.
```

**Testing Bikelanes**
- https://www.openstreetmap.org/way/87314813 – gute Ergänzung
- https://www.openstreetmap.org/way/118192520 – eher schlechte Ergänzung da nicht Teil des Netzes
- https://www.openstreetmap.org/way/164645007 - ok

**Testing roads**
- https://www.openstreetmap.org/way/440228134 besser `{"CHANGE": "modified", "bikelane_self": "\"footAndCyclewaySegregated_adjoiningOrIsolated\" -> \"livingStreet\""}`
- Viele Änderungen `{"CHANGE": "modified", "bikelane_self": "\"not_expected\" -> \"livingStreet\""}` => besser
- 